### PR TITLE
refactor(jwt): refactor export in `jwt`

### DIFF
--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -2,17 +2,13 @@ import { URL } from "node:url";
 import * as jose from "jose";
 import { getJwtTools, TypedJWTPayload } from "grindery-nexus-common-utils";
 
-const ISSUER = "urn:grindery:web3-driver";
-
-const jwtTools = getJwtTools(ISSUER);
+const jwtTools = getJwtTools("urn:grindery:web3-driver");
 jwtTools.getPublicJwk().catch((e) => {
   console.error("Failed to initialize keys:", e);
   process.exit(1);
 });
 
-const { encryptJWT, decryptJWT, signJWT, verifyJWT, getPublicJwk, typedCipher, typedToken, hmac } = jwtTools;
-export { encryptJWT, decryptJWT, signJWT, verifyJWT, getPublicJwk, typedCipher, typedToken, hmac };
-
+export const { encryptJWT, decryptJWT, signJWT, verifyJWT, getPublicJwk, typedCipher, typedToken, hmac } = jwtTools;
 export const FlowAddressToken = typedCipher("urn:grindery:web3-driver:flow-address-token");
 
 type AccessTokenExtra =
@@ -28,6 +24,7 @@ export type TAccessToken = TypedJWTPayload<AccessTokenExtra>;
 const ORCHESTRATOR_KEY = jose.createRemoteJWKSet(
   new URL(process.env.ORCHESTRATOR_PUBLIC_KEY || "https://orchestrator.grindery.org/oauth/jwks")
 );
+
 export async function parseUserAccessToken(token: string): Promise<TAccessToken> {
   const { payload } = await jose.jwtVerify(token, ORCHESTRATOR_KEY, {
     issuer: "urn:grindery:orchestrator",


### PR DESCRIPTION
A small refactoring to:
- Put the `jwtTools` export in one line.
- Remove the `ISSUER` constant that is only used once.