### PR TITLE
feat(actions): move specific actions to dedicated folders

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,7 +6,7 @@
   "bracketSameLine": false,
   "jsxBracketSameLine": false,
   "jsxSingleQuote": false,
-  "printWidth": 100,
+  "printWidth": 120,
   "proseWrap": "preserve",
   "quoteProps": "as-needed",
   "semi": true,

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,7 +6,7 @@
   "bracketSameLine": false,
   "jsxBracketSameLine": false,
   "jsxSingleQuote": false,
-  "printWidth": 120,
+  "printWidth": 100,
   "proseWrap": "preserve",
   "quoteProps": "as-needed",
   "semi": true,

--- a/src/connector/index.ts
+++ b/src/connector/index.ts
@@ -7,7 +7,7 @@ import {
   genericAbiTriggerInputProvider,
 } from "../web3/evm/connector/genericAbi";
 import { clkPriceFeedAction, clkPriceFeedActionInputProvider } from "../web3/evm/connector/chainlink";
-
+import { balanceOfActionERC20 } from "../web3/evm/connector/erc20";
 import { gnosisSafeSimpleTransfer, gnosisSafeSimpleTransferToken } from "../web3/evm/connector/gnosisSafe";
 import {
   safeTransactionExecutedAddOwner,
@@ -35,6 +35,7 @@ export const CONNECTOR_DEFINITION: ConnectorDefinition = {
     gnosisSafeSimpleTransfer,
     gnosisSafeSimpleTransferToken,
     layerZeroUpdateHash,
+    balanceOfActionERC20,
   },
   triggers: {
     newTransaction: { factory: setupSignal },

--- a/src/connector/index.ts
+++ b/src/connector/index.ts
@@ -7,7 +7,13 @@ import {
   genericAbiTriggerInputProvider,
 } from "../web3/evm/connector/genericAbi";
 import { clkPriceFeedAction, clkPriceFeedActionInputProvider } from "../web3/evm/connector/chainlink";
-import { balanceOfActionERC20 } from "../web3/evm/connector/erc20";
+import {
+  balanceOfActionERC20,
+  InformationERC20TokenAction,
+  totalSupplyAction,
+  allowanceAction,
+} from "../web3/evm/connector/erc20";
+import { InformationInvestmentClub } from "../web3/evm/connector/syndicate";
 import { gnosisSafeSimpleTransfer, gnosisSafeSimpleTransferToken } from "../web3/evm/connector/gnosisSafe";
 import {
   safeTransactionExecutedAddOwner,
@@ -36,6 +42,10 @@ export const CONNECTOR_DEFINITION: ConnectorDefinition = {
     gnosisSafeSimpleTransferToken,
     layerZeroUpdateHash,
     balanceOfActionERC20,
+    InformationERC20TokenAction,
+    totalSupplyAction,
+    allowanceAction,
+    InformationInvestmentClub,
   },
   triggers: {
     newTransaction: { factory: setupSignal },

--- a/src/connector/index.ts
+++ b/src/connector/index.ts
@@ -14,6 +14,7 @@ import {
   allowanceAction,
 } from "../web3/evm/connector/erc20";
 import { InformationInvestmentClub } from "../web3/evm/connector/syndicate";
+import { getBalanceNative } from "../web3/evm/connector/evmWallet";
 import { gnosisSafeSimpleTransfer, gnosisSafeSimpleTransferToken } from "../web3/evm/connector/gnosisSafe";
 import {
   safeTransactionExecutedAddOwner,
@@ -46,6 +47,7 @@ export const CONNECTOR_DEFINITION: ConnectorDefinition = {
     totalSupplyAction,
     allowanceAction,
     InformationInvestmentClub,
+    getBalanceNative,
   },
   triggers: {
     newTransaction: { factory: setupSignal },

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -74,14 +74,18 @@ async function prepareRoutedTransaction<T extends Partial<TransactionConfig> | T
   if (hasDrone) {
     nonce = await droneContract.methods.getNextNonce().call();
   }
-  const transactionHash = await hubContract.methods.getTransactionHash(droneAddress, tx.to, nonce, tx.data).call();
+  const transactionHash = await hubContract.methods
+    .getTransactionHash(droneAddress, tx.to, nonce, tx.data)
+    .call();
   const signature = await vaultSigner.signMessage(transactionHash);
   tx = { ...tx };
   if (hasDrone) {
     tx.data = droneContract.methods.sendTransaction(tx.to, nonce, tx.data, signature).encodeABI();
     tx.to = droneAddress;
   } else {
-    tx.data = hubContract.methods.deployDroneAndSendTransaction(userAddress, tx.to, tx.data, signature).encodeABI();
+    tx.data = hubContract.methods
+      .deployDroneAndSendTransaction(userAddress, tx.to, tx.data, signature)
+      .encodeABI();
     tx.to = HUB_ADDRESS;
   }
   return { tx, droneAddress };
@@ -104,9 +108,9 @@ export async function callSmartContract(
   if (!input.fields._grinderyUserToken) {
     console.warn("_grinderyUserToken is not available");
   }
-  const user = await parseUserAccessToken(input.fields._grinderyUserToken || input.fields.userToken || "").catch(
-    () => null
-  );
+  const user = await parseUserAccessToken(
+    input.fields._grinderyUserToken || input.fields.userToken || ""
+  ).catch(() => null);
   if (!user) {
     throw new Error("User token is invalid");
   }
@@ -116,7 +120,9 @@ export async function callSmartContract(
     /* A function that returns the balance of an address. */
     if (input.fields.functionDeclaration === "getBalanceNative") {
       const address = input.fields.parameters.address as string;
-      const balance = await web3.eth.getBalance(address).then((result) => web3.utils.fromWei(result));
+      const balance = await web3.eth
+        .getBalance(address)
+        .then((result) => web3.utils.fromWei(result));
 
       return {
         key: input.key,
@@ -125,29 +131,31 @@ export async function callSmartContract(
       };
     }
 
-    /* The above code is a TypeScript function that is executed when the functionDeclaration is
-    getBalance. It takes the contractAddress and address from the input and uses them to call the
-    balanceOf() function on the contract. It then returns the balance in the payload. */
-    if (input.fields.functionDeclaration === "getBalanceERC20Token") {
-      const tokenAddress = input.fields.contractAddress;
-      const tokenHolder = input.fields.parameters.address;
-      const balanceOfAbi = ERC20;
+    // /* The above code is a TypeScript function that is executed when the functionDeclaration is
+    // getBalance. It takes the contractAddress and address from the input and uses them to call the
+    // balanceOf() function on the contract. It then returns the balance in the payload. */
+    // if (input.fields.functionDeclaration === "getBalanceERC20Token") {
+    //   const tokenAddress = input.fields.contractAddress;
+    //   const tokenHolder = input.fields.parameters.address;
+    //   const balanceOfAbi = ERC20;
 
-      // Define the ERC-20 token contract
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const contract = new web3.eth.Contract(balanceOfAbi as any, tokenAddress);
+    //   // Define the ERC-20 token contract
+    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    //   const contract = new web3.eth.Contract(balanceOfAbi as any, tokenAddress);
 
-      // Execute balanceOf() to retrieve the token balance
-      const balanceWei = await contract.methods.balanceOf(tokenHolder).call();
-      const decimals = await contract.methods.decimals().call();
-      const balanceTokenUnit = BigNumber.from(balanceWei).div(BigNumber.from(10).pow(BigNumber.from(decimals)));
+    //   // Execute balanceOf() to retrieve the token balance
+    //   const balanceWei = await contract.methods.balanceOf(tokenHolder).call();
+    //   const decimals = await contract.methods.decimals().call();
+    //   const balanceTokenUnit = BigNumber.from(balanceWei).div(
+    //     BigNumber.from(10).pow(BigNumber.from(decimals))
+    //   );
 
-      return {
-        key: input.key,
-        sessionId: input.sessionId,
-        payload: { balance: balanceTokenUnit.toString() },
-      };
-    }
+    //   return {
+    //     key: input.key,
+    //     sessionId: input.sessionId,
+    //     payload: { balance: balanceTokenUnit.toString() },
+    //   };
+    // }
 
     /* Getting the symbol, decimals and name of the token. */
     if (input.fields.functionDeclaration === "getInformationERC20Token") {
@@ -174,7 +182,9 @@ export async function callSmartContract(
         .allowance(input.fields.parameters.owner, input.fields.parameters.spender)
         .call();
       const decimals = await tokenContract.methods.decimals().call();
-      const allowanceTokenUnit = BigNumber.from(allowance).div(BigNumber.from(10).pow(BigNumber.from(decimals)));
+      const allowanceTokenUnit = BigNumber.from(allowance).div(
+        BigNumber.from(10).pow(BigNumber.from(decimals))
+      );
 
       return {
         key: input.key,
@@ -191,7 +201,9 @@ export async function callSmartContract(
       const tokenContract = new web3.eth.Contract(ERC20 as any, input.fields.contractAddress);
       const totalSupply = await tokenContract.methods.totalSupply().call();
       const decimals = await tokenContract.methods.decimals().call();
-      const totalSupplyTokenUnit = BigNumber.from(totalSupply).div(BigNumber.from(10).pow(BigNumber.from(decimals)));
+      const totalSupplyTokenUnit = BigNumber.from(totalSupply).div(
+        BigNumber.from(10).pow(BigNumber.from(decimals))
+      );
 
       return {
         key: input.key,
@@ -265,7 +277,9 @@ export async function callSmartContract(
         console.log("hjsj");
         paramArray.push(input.fields.parameters.recipient);
         const metadata = JSON.stringify(
-          (({ name, description, image }) => ({ name, description, image }))(input.fields.parameters)
+          (({ name, description, image }) => ({ name, description, image }))(
+            input.fields.parameters
+          )
         );
 
         const config: AxiosRequestConfig = {
@@ -340,7 +354,10 @@ export async function callSmartContract(
           }
           if (functionInfo.outputs?.length) {
             if (decoded.returnData && (decoded.returnData.toLowerCase?.() || "0x") !== "0x") {
-              callResultDecoded = web3.eth.abi.decodeParameters(functionInfo.outputs || [], decoded.returnData);
+              callResultDecoded = web3.eth.abi.decodeParameters(
+                functionInfo.outputs || [],
+                decoded.returnData
+              );
               if (functionInfo.outputs.length === 1) {
                 callResultDecoded = callResultDecoded[0];
               }
@@ -360,12 +377,15 @@ export async function callSmartContract(
           sessionId: input.sessionId,
           payload: {
             _grinderyDryRunError:
-              "Can't confirm that the transaction can be executed due to the following error: " + e.toString(),
+              "Can't confirm that the transaction can be executed due to the following error: " +
+              e.toString(),
           },
         };
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      txConfig.nonce = web3.utils.toHex(await web3.eth.getTransactionCount(web3.defaultAccount)) as any;
+      txConfig.nonce = web3.utils.toHex(
+        await web3.eth.getTransactionCount(web3.defaultAccount)
+      ) as any;
       let result: unknown;
       for (const key of ["gasLimit", "maxFeePerGas", "maxPriorityFeePerGas"]) {
         if (key in input.fields && typeof input.fields[key] === "string") {
@@ -392,7 +412,10 @@ export async function callSmartContract(
             `Gas limit of ${web3.utils.fromWei(
               String(input.fields.gasLimit),
               "ether"
-            )} is too low, need at least ${web3.utils.fromWei(minFee.mul(txConfig.gas || 1).toString(), "ether")}`
+            )} is too low, need at least ${web3.utils.fromWei(
+              minFee.mul(txConfig.gas || 1).toString(),
+              "ether"
+            )}`
           );
         }
         txConfig.maxFeePerGas = maxFee.toHexString();
@@ -421,18 +444,26 @@ export async function callSmartContract(
           ...(txConfig.maxFeePerGas
             ? {
                 type: 2,
-                maxFeePerGas: txConfig.maxFeePerGas ? BigNumber.from(txConfig.maxFeePerGas).toHexString() : undefined,
+                maxFeePerGas: txConfig.maxFeePerGas
+                  ? BigNumber.from(txConfig.maxFeePerGas).toHexString()
+                  : undefined,
                 maxPriorityFeePerGas: txConfig.maxPriorityFeePerGas
                   ? BigNumber.from(txConfig.maxPriorityFeePerGas).toHexString()
                   : undefined,
               }
-            : { gasPrice: txConfig.gasPrice ? BigNumber.from(txConfig.gasPrice).toHexString() : undefined }),
+            : {
+                gasPrice: txConfig.gasPrice
+                  ? BigNumber.from(txConfig.gasPrice).toHexString()
+                  : undefined,
+              }),
         });
         const receipt = await web3.eth.sendSignedTransaction(signedTransaction);
         releaseLock(); // Block less time
         result = receipt;
         const cost = BigNumber.from(receipt.gasUsed || txConfig.gas)
-          .mul(BigNumber.from(receipt.effectiveGasPrice || txConfig.gasPrice || txConfig.maxFeePerGas))
+          .mul(
+            BigNumber.from(receipt.effectiveGasPrice || txConfig.gasPrice || txConfig.maxFeePerGas)
+          )
           .toString();
 
         // console.log("result: " + JSON.stringify(result))
@@ -470,18 +501,31 @@ export async function callSmartContract(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             eventAbi as any
           );
-          const log = receipt.logs.find((x) => x.topics?.[0] === eventSignature && x.address === droneAddress);
+          const log = receipt.logs.find(
+            (x) => x.topics?.[0] === eventSignature && x.address === droneAddress
+          );
           if (!log) {
             throw new Error("No transaction result log in receipt");
           }
-          const resultData = web3.eth.abi.decodeLog(eventAbi?.inputs || [], log.data, log.topics.slice(1));
+          const resultData = web3.eth.abi.decodeLog(
+            eventAbi?.inputs || [],
+            log.data,
+            log.topics.slice(1)
+          );
           if (resultData.success) {
             if (functionInfo.outputs?.length) {
-              callResultDecoded = web3.eth.abi.decodeParameters(functionInfo.outputs || [], resultData.returnData);
+              callResultDecoded = web3.eth.abi.decodeParameters(
+                functionInfo.outputs || [],
+                resultData.returnData
+              );
               if (functionInfo.outputs.length === 1) {
                 callResultDecoded = callResultDecoded[0];
               }
-              result = { ...receipt, returnValue: callResultDecoded, contractAddress: input.fields.contractAddress };
+              result = {
+                ...receipt,
+                returnValue: callResultDecoded,
+                contractAddress: input.fields.contractAddress,
+              };
               console.log("result", result);
             }
           } else {

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -13,8 +13,6 @@ import { BigNumber } from "@ethersproject/bignumber";
 
 import GrinderyNexusDrone from "./abi/GrinderyNexusDrone.json";
 import GrinderyNexusHub from "./abi/GrinderyNexusHub.json";
-import ERC20 from "./abi/ERC20.json";
-import SyndicateERC721 from "./abi/ERC721Collective.json";
 import vaultSigner from "./signer";
 
 const hubAvailability = new Map<string, boolean>();

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -113,18 +113,6 @@ export async function callSmartContract(
   const address = await vaultSigner.getAddress();
   const { web3, close, ethersProvider } = getWeb3(input.fields.chain);
   try {
-    /* A function that returns the balance of an address. */
-    if (input.fields.functionDeclaration === "getBalanceNative") {
-      const address = input.fields.parameters.address as string;
-      const balance = await web3.eth.getBalance(address).then((result) => web3.utils.fromWei(result));
-
-      return {
-        key: input.key,
-        sessionId: input.sessionId,
-        payload: { balance },
-      };
-    }
-
     const userAddress = await getUserAddress(user);
     web3.eth.transactionConfirmationBlocks = 1;
     if (!web3.defaultAccount) {

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -74,18 +74,14 @@ async function prepareRoutedTransaction<T extends Partial<TransactionConfig> | T
   if (hasDrone) {
     nonce = await droneContract.methods.getNextNonce().call();
   }
-  const transactionHash = await hubContract.methods
-    .getTransactionHash(droneAddress, tx.to, nonce, tx.data)
-    .call();
+  const transactionHash = await hubContract.methods.getTransactionHash(droneAddress, tx.to, nonce, tx.data).call();
   const signature = await vaultSigner.signMessage(transactionHash);
   tx = { ...tx };
   if (hasDrone) {
     tx.data = droneContract.methods.sendTransaction(tx.to, nonce, tx.data, signature).encodeABI();
     tx.to = droneAddress;
   } else {
-    tx.data = hubContract.methods
-      .deployDroneAndSendTransaction(userAddress, tx.to, tx.data, signature)
-      .encodeABI();
+    tx.data = hubContract.methods.deployDroneAndSendTransaction(userAddress, tx.to, tx.data, signature).encodeABI();
     tx.to = HUB_ADDRESS;
   }
   return { tx, droneAddress };
@@ -108,9 +104,9 @@ export async function callSmartContract(
   if (!input.fields._grinderyUserToken) {
     console.warn("_grinderyUserToken is not available");
   }
-  const user = await parseUserAccessToken(
-    input.fields._grinderyUserToken || input.fields.userToken || ""
-  ).catch(() => null);
+  const user = await parseUserAccessToken(input.fields._grinderyUserToken || input.fields.userToken || "").catch(
+    () => null
+  );
   if (!user) {
     throw new Error("User token is invalid");
   }
@@ -120,123 +116,12 @@ export async function callSmartContract(
     /* A function that returns the balance of an address. */
     if (input.fields.functionDeclaration === "getBalanceNative") {
       const address = input.fields.parameters.address as string;
-      const balance = await web3.eth
-        .getBalance(address)
-        .then((result) => web3.utils.fromWei(result));
+      const balance = await web3.eth.getBalance(address).then((result) => web3.utils.fromWei(result));
 
       return {
         key: input.key,
         sessionId: input.sessionId,
         payload: { balance },
-      };
-    }
-
-    // /* The above code is a TypeScript function that is executed when the functionDeclaration is
-    // getBalance. It takes the contractAddress and address from the input and uses them to call the
-    // balanceOf() function on the contract. It then returns the balance in the payload. */
-    // if (input.fields.functionDeclaration === "getBalanceERC20Token") {
-    //   const tokenAddress = input.fields.contractAddress;
-    //   const tokenHolder = input.fields.parameters.address;
-    //   const balanceOfAbi = ERC20;
-
-    //   // Define the ERC-20 token contract
-    //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    //   const contract = new web3.eth.Contract(balanceOfAbi as any, tokenAddress);
-
-    //   // Execute balanceOf() to retrieve the token balance
-    //   const balanceWei = await contract.methods.balanceOf(tokenHolder).call();
-    //   const decimals = await contract.methods.decimals().call();
-    //   const balanceTokenUnit = BigNumber.from(balanceWei).div(
-    //     BigNumber.from(10).pow(BigNumber.from(decimals))
-    //   );
-
-    //   return {
-    //     key: input.key,
-    //     sessionId: input.sessionId,
-    //     payload: { balance: balanceTokenUnit.toString() },
-    //   };
-    // }
-
-    /* Getting the symbol, decimals and name of the token. */
-    if (input.fields.functionDeclaration === "getInformationERC20Token") {
-      const abiOfToken = ERC20;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const tokenContract = new web3.eth.Contract(abiOfToken as any, input.fields.contractAddress);
-
-      return {
-        key: input.key,
-        sessionId: input.sessionId,
-        payload: {
-          symbol: await tokenContract.methods.symbol().call(),
-          decimals: (await tokenContract.methods.decimals().call()).toString(),
-          name: await tokenContract.methods.name().call(),
-        },
-      };
-    }
-
-    /* Getting the allowance of an ERC20 token. */
-    if (input.fields.functionDeclaration === "getAllowanceERC20Token") {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const tokenContract = new web3.eth.Contract(ERC20 as any, input.fields.contractAddress);
-      const allowance = await tokenContract.methods
-        .allowance(input.fields.parameters.owner, input.fields.parameters.spender)
-        .call();
-      const decimals = await tokenContract.methods.decimals().call();
-      const allowanceTokenUnit = BigNumber.from(allowance).div(
-        BigNumber.from(10).pow(BigNumber.from(decimals))
-      );
-
-      return {
-        key: input.key,
-        sessionId: input.sessionId,
-        payload: {
-          allowance: allowanceTokenUnit.toString(),
-        },
-      };
-    }
-
-    /* Getting the total supply of an ERC20 token. */
-    if (input.fields.functionDeclaration === "getTotalSupplyERC20Token") {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const tokenContract = new web3.eth.Contract(ERC20 as any, input.fields.contractAddress);
-      const totalSupply = await tokenContract.methods.totalSupply().call();
-      const decimals = await tokenContract.methods.decimals().call();
-      const totalSupplyTokenUnit = BigNumber.from(totalSupply).div(
-        BigNumber.from(10).pow(BigNumber.from(decimals))
-      );
-
-      return {
-        key: input.key,
-        sessionId: input.sessionId,
-        payload: {
-          totalSupply: totalSupplyTokenUnit.toString(),
-        },
-      };
-    }
-    /* Calling the getSyndicateInvestmentClubInformation function on the SyndicateERC721 contract. */
-    if (input.fields.functionDeclaration === "getSyndicateInvestmentClubInformation") {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const contract = new web3.eth.Contract(SyndicateERC721 as any, input.fields.contractAddress);
-
-      const owner = await contract.methods.owner().call();
-      const name = await contract.methods.name().call();
-      const symbol = await contract.methods.symbol().call();
-      const totalSupply = await contract.methods
-        .totalSupply()
-        .call()
-        .then((result) => web3.utils.fromWei(result));
-
-      console.log(owner, name, symbol, totalSupply);
-
-      return {
-        key: input.key,
-        sessionId: input.sessionId,
-        payload: {
-          owner,
-          name,
-          symbol,
-          totalSupply: totalSupply.toString(),
-        },
       };
     }
 
@@ -277,9 +162,7 @@ export async function callSmartContract(
         console.log("hjsj");
         paramArray.push(input.fields.parameters.recipient);
         const metadata = JSON.stringify(
-          (({ name, description, image }) => ({ name, description, image }))(
-            input.fields.parameters
-          )
+          (({ name, description, image }) => ({ name, description, image }))(input.fields.parameters)
         );
 
         const config: AxiosRequestConfig = {
@@ -354,10 +237,7 @@ export async function callSmartContract(
           }
           if (functionInfo.outputs?.length) {
             if (decoded.returnData && (decoded.returnData.toLowerCase?.() || "0x") !== "0x") {
-              callResultDecoded = web3.eth.abi.decodeParameters(
-                functionInfo.outputs || [],
-                decoded.returnData
-              );
+              callResultDecoded = web3.eth.abi.decodeParameters(functionInfo.outputs || [], decoded.returnData);
               if (functionInfo.outputs.length === 1) {
                 callResultDecoded = callResultDecoded[0];
               }
@@ -377,15 +257,12 @@ export async function callSmartContract(
           sessionId: input.sessionId,
           payload: {
             _grinderyDryRunError:
-              "Can't confirm that the transaction can be executed due to the following error: " +
-              e.toString(),
+              "Can't confirm that the transaction can be executed due to the following error: " + e.toString(),
           },
         };
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      txConfig.nonce = web3.utils.toHex(
-        await web3.eth.getTransactionCount(web3.defaultAccount)
-      ) as any;
+      txConfig.nonce = web3.utils.toHex(await web3.eth.getTransactionCount(web3.defaultAccount)) as any;
       let result: unknown;
       for (const key of ["gasLimit", "maxFeePerGas", "maxPriorityFeePerGas"]) {
         if (key in input.fields && typeof input.fields[key] === "string") {
@@ -412,10 +289,7 @@ export async function callSmartContract(
             `Gas limit of ${web3.utils.fromWei(
               String(input.fields.gasLimit),
               "ether"
-            )} is too low, need at least ${web3.utils.fromWei(
-              minFee.mul(txConfig.gas || 1).toString(),
-              "ether"
-            )}`
+            )} is too low, need at least ${web3.utils.fromWei(minFee.mul(txConfig.gas || 1).toString(), "ether")}`
           );
         }
         txConfig.maxFeePerGas = maxFee.toHexString();
@@ -444,26 +318,20 @@ export async function callSmartContract(
           ...(txConfig.maxFeePerGas
             ? {
                 type: 2,
-                maxFeePerGas: txConfig.maxFeePerGas
-                  ? BigNumber.from(txConfig.maxFeePerGas).toHexString()
-                  : undefined,
+                maxFeePerGas: txConfig.maxFeePerGas ? BigNumber.from(txConfig.maxFeePerGas).toHexString() : undefined,
                 maxPriorityFeePerGas: txConfig.maxPriorityFeePerGas
                   ? BigNumber.from(txConfig.maxPriorityFeePerGas).toHexString()
                   : undefined,
               }
             : {
-                gasPrice: txConfig.gasPrice
-                  ? BigNumber.from(txConfig.gasPrice).toHexString()
-                  : undefined,
+                gasPrice: txConfig.gasPrice ? BigNumber.from(txConfig.gasPrice).toHexString() : undefined,
               }),
         });
         const receipt = await web3.eth.sendSignedTransaction(signedTransaction);
         releaseLock(); // Block less time
         result = receipt;
         const cost = BigNumber.from(receipt.gasUsed || txConfig.gas)
-          .mul(
-            BigNumber.from(receipt.effectiveGasPrice || txConfig.gasPrice || txConfig.maxFeePerGas)
-          )
+          .mul(BigNumber.from(receipt.effectiveGasPrice || txConfig.gasPrice || txConfig.maxFeePerGas))
           .toString();
 
         // console.log("result: " + JSON.stringify(result))
@@ -501,23 +369,14 @@ export async function callSmartContract(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             eventAbi as any
           );
-          const log = receipt.logs.find(
-            (x) => x.topics?.[0] === eventSignature && x.address === droneAddress
-          );
+          const log = receipt.logs.find((x) => x.topics?.[0] === eventSignature && x.address === droneAddress);
           if (!log) {
             throw new Error("No transaction result log in receipt");
           }
-          const resultData = web3.eth.abi.decodeLog(
-            eventAbi?.inputs || [],
-            log.data,
-            log.topics.slice(1)
-          );
+          const resultData = web3.eth.abi.decodeLog(eventAbi?.inputs || [], log.data, log.topics.slice(1));
           if (resultData.success) {
             if (functionInfo.outputs?.length) {
-              callResultDecoded = web3.eth.abi.decodeParameters(
-                functionInfo.outputs || [],
-                resultData.returnData
-              );
+              callResultDecoded = web3.eth.abi.decodeParameters(functionInfo.outputs || [], resultData.returnData);
               if (functionInfo.outputs.length === 1) {
                 callResultDecoded = callResultDecoded[0];
               }

--- a/src/web3/evm/connector/chainlink/action.ts
+++ b/src/web3/evm/connector/chainlink/action.ts
@@ -1,16 +1,7 @@
-import {
-  ConnectorInput,
-  ActionOutput,
-  InputProviderInput,
-  InputProviderOutput
-} from "grindery-nexus-common-utils";
+import { ConnectorInput, ActionOutput, InputProviderInput, InputProviderOutput } from "grindery-nexus-common-utils";
 import { callSmartContract } from "../../call";
 import { sanitizeParameters } from "../../../../utils";
-import {
-  prepareOutputChainlink,
-  clkFields,
-  extractAddressFromPair
-} from "./common";
+import { prepareOutputChainlink, clkFields, extractAddressFromPair } from "./common";
 import BigNumber from "bignumber.js";
 
 /**
@@ -18,10 +9,10 @@ import BigNumber from "bignumber.js";
  * @param params - InputProviderInput<unknown>
  * @returns The return value is a JSON object that contains the following fields:
  */
-export async function clkPriceFeedActionInputProvider(params: InputProviderInput<unknown>): Promise<InputProviderOutput> {
-  return await prepareOutputChainlink(
-    params.fieldData as clkFields
-  );
+export async function clkPriceFeedActionInputProvider(
+  params: InputProviderInput<unknown>
+): Promise<InputProviderOutput> {
+  return await prepareOutputChainlink(params.fieldData as clkFields);
 }
 
 /**
@@ -34,28 +25,32 @@ export async function clkPriceFeedAction(input: ConnectorInput<unknown>): Promis
   const fields = input.fields as clkFields;
   const contractAddr = await extractAddressFromPair(fields._getChainlinkPriceFeed);
   /* Calling the smart contract to get the decimals of the token. */
-  const getDecimals = await callSmartContract(await sanitizeParameters({
-    ...input,
-    fields: {
-      ...fields,
-      chain: fields._grinderyChain,
-      contractAddress: contractAddr,
-      functionDeclaration: "function decimals() view returns (uint8)",
-      parameters: {},
-    },
-  }));
+  const getDecimals = await callSmartContract(
+    await sanitizeParameters({
+      ...input,
+      fields: {
+        ...fields,
+        chain: fields._grinderyChain,
+        contractAddress: contractAddr,
+        functionDeclaration: "function decimals() view returns (uint8)",
+        parameters: {},
+      },
+    })
+  );
   const decimals = new BigNumber((getDecimals.payload as any).returnValue);
   /* Getting the pair from the smart contract. */
-  const getPair = await callSmartContract(await sanitizeParameters({
-    ...input,
-    fields: {
-      ...fields,
-      chain: fields._grinderyChain,
-      contractAddress: contractAddr,
-      functionDeclaration: "function description() view returns (string)",
-      parameters: {},
-    },
-  }));
+  const getPair = await callSmartContract(
+    await sanitizeParameters({
+      ...input,
+      fields: {
+        ...fields,
+        chain: fields._grinderyChain,
+        contractAddress: contractAddr,
+        functionDeclaration: "function description() view returns (string)",
+        parameters: {},
+      },
+    })
+  );
   /* Calling the smart contract to get the latest round data. */
   const res = await callSmartContract(
     await sanitizeParameters({
@@ -71,13 +66,11 @@ export async function clkPriceFeedAction(input: ConnectorInput<unknown>): Promis
   );
   /* Converting the exchange rate from the smart contract to a human readable format. */
   res.payload = {
-    _exchangeRate: new BigNumber(
-      (res.payload as any).returnValue.return1
-    ).div(
-      new BigNumber(10).pow(decimals)
-    ).toString(),
+    _exchangeRate: new BigNumber((res.payload as any).returnValue.return1)
+      .div(new BigNumber(10).pow(decimals))
+      .toString(),
     _pair: (getPair.payload as any).returnValue,
-    _contractAddress: contractAddr
+    _contractAddress: contractAddr,
   };
   return res;
 }

--- a/src/web3/evm/connector/erc20/actions/allowance.ts
+++ b/src/web3/evm/connector/erc20/actions/allowance.ts
@@ -3,24 +3,17 @@ import { callSmartContract } from "../../../call";
 import { sanitizeParameters } from "../../../../../utils";
 import { BigNumber } from "@ethersproject/bignumber";
 
-export async function balanceOfActionERC20(input: ConnectorInput<unknown>): Promise<ActionOutput> {
+export async function allowanceAction(input: ConnectorInput<unknown>): Promise<ActionOutput> {
   const fields = input.fields as {
-    [key: string]: string | { address: string };
+    [key: string]: string;
   };
 
-  const getBalance = await callSmartContract(
+  const getAllowance = await callSmartContract(
     await sanitizeParameters({
       ...input,
       fields: {
         ...fields,
-        functionDeclaration: "function balanceOf(address account) view returns (uint256)",
-        parameters: {
-          account: (
-            fields.parameters as {
-              address: string;
-            }
-          ).address,
-        },
+        functionDeclaration: "function allowance(address owner, address spender) view returns (uint256)",
       },
     })
   );
@@ -37,11 +30,11 @@ export async function balanceOfActionERC20(input: ConnectorInput<unknown>): Prom
   );
 
   return {
-    ...getBalance,
+    ...getAllowance,
     payload: {
-      balance: BigNumber.from(
+      allowance: BigNumber.from(
         (
-          getBalance.payload as {
+          getAllowance.payload as {
             returnValue: string;
           }
         ).returnValue

--- a/src/web3/evm/connector/erc20/actions/balanceOf.ts
+++ b/src/web3/evm/connector/erc20/actions/balanceOf.ts
@@ -1,0 +1,64 @@
+import { ActionOutput, ConnectorInput } from "grindery-nexus-common-utils";
+import { callSmartContract } from "../../../call";
+import { sanitizeParameters } from "../../../../../utils";
+import { BigNumber } from "@ethersproject/bignumber";
+
+export async function balanceOfActionERC20(input: ConnectorInput<unknown>): Promise<ActionOutput> {
+  const fields = input.fields as {
+    [key: string]: string | { address: string };
+  };
+
+  const getBalance = await callSmartContract(
+    await sanitizeParameters({
+      ...input,
+      fields: {
+        ...fields,
+        functionDeclaration: "function balanceOf(address account) view returns (uint256)",
+        parameters: {
+          account: (
+            fields.parameters as {
+              address: string;
+            }
+          ).address,
+        },
+      },
+    })
+  );
+
+  const getDecimals = await callSmartContract(
+    await sanitizeParameters({
+      ...input,
+      fields: {
+        ...fields,
+        functionDeclaration: "function decimals() view returns (uint256)",
+        parameters: {},
+      },
+    })
+  );
+
+  return {
+    ...getBalance,
+    payload: {
+      ...(getBalance.payload as object),
+      returnValue: BigNumber.from(
+        (
+          getBalance.payload as {
+            returnValue: string;
+          }
+        ).returnValue
+      )
+        .div(
+          BigNumber.from(10).pow(
+            BigNumber.from(
+              (
+                getDecimals.payload as {
+                  returnValue: string;
+                }
+              ).returnValue
+            )
+          )
+        )
+        .toString(),
+    },
+  };
+}

--- a/src/web3/evm/connector/erc20/actions/information.ts
+++ b/src/web3/evm/connector/erc20/actions/information.ts
@@ -1,0 +1,63 @@
+import { ActionOutput, ConnectorInput } from "grindery-nexus-common-utils";
+import { callSmartContract } from "../../../call";
+import { sanitizeParameters } from "../../../../../utils";
+
+export async function InformationERC20TokenAction(input: ConnectorInput<unknown>): Promise<ActionOutput> {
+  const fields = input.fields as {
+    [key: string]: string;
+  };
+
+  const getSymbol = await callSmartContract(
+    await sanitizeParameters({
+      ...input,
+      fields: {
+        ...fields,
+        functionDeclaration: "function symbol() view returns (string)",
+        parameters: {},
+      },
+    })
+  );
+
+  const getDecimals = await callSmartContract(
+    await sanitizeParameters({
+      ...input,
+      fields: {
+        ...fields,
+        functionDeclaration: "function decimals() view returns (uint256)",
+        parameters: {},
+      },
+    })
+  );
+
+  const getName = await callSmartContract(
+    await sanitizeParameters({
+      ...input,
+      fields: {
+        ...fields,
+        functionDeclaration: "function name() view returns (string)",
+        parameters: {},
+      },
+    })
+  );
+
+  return {
+    ...getName,
+    payload: {
+      symbol: (
+        getSymbol.payload as {
+          returnValue: string;
+        }
+      ).returnValue,
+      name: (
+        getName.payload as {
+          returnValue: string;
+        }
+      ).returnValue,
+      decimals: (
+        getDecimals.payload as {
+          returnValue: string;
+        }
+      ).returnValue,
+    },
+  };
+}

--- a/src/web3/evm/connector/erc20/actions/totalSupply.ts
+++ b/src/web3/evm/connector/erc20/actions/totalSupply.ts
@@ -3,24 +3,18 @@ import { callSmartContract } from "../../../call";
 import { sanitizeParameters } from "../../../../../utils";
 import { BigNumber } from "@ethersproject/bignumber";
 
-export async function balanceOfActionERC20(input: ConnectorInput<unknown>): Promise<ActionOutput> {
+export async function totalSupplyAction(input: ConnectorInput<unknown>): Promise<ActionOutput> {
   const fields = input.fields as {
-    [key: string]: string | { address: string };
+    [key: string]: string;
   };
 
-  const getBalance = await callSmartContract(
+  const getTotalSupply = await callSmartContract(
     await sanitizeParameters({
       ...input,
       fields: {
         ...fields,
-        functionDeclaration: "function balanceOf(address account) view returns (uint256)",
-        parameters: {
-          account: (
-            fields.parameters as {
-              address: string;
-            }
-          ).address,
-        },
+        functionDeclaration: "function totalSupply() view returns (uint256)",
+        parameters: {},
       },
     })
   );
@@ -37,11 +31,11 @@ export async function balanceOfActionERC20(input: ConnectorInput<unknown>): Prom
   );
 
   return {
-    ...getBalance,
+    ...getTotalSupply,
     payload: {
-      balance: BigNumber.from(
+      totalSupply: BigNumber.from(
         (
-          getBalance.payload as {
+          getTotalSupply.payload as {
             returnValue: string;
           }
         ).returnValue

--- a/src/web3/evm/connector/erc20/index.ts
+++ b/src/web3/evm/connector/erc20/index.ts
@@ -1,1 +1,4 @@
 export * from "./actions/balanceOf";
+export * from "./actions/information";
+export * from "./actions/totalSupply";
+export * from "./actions/allowance";

--- a/src/web3/evm/connector/erc20/index.ts
+++ b/src/web3/evm/connector/erc20/index.ts
@@ -1,0 +1,1 @@
+export * from "./actions/balanceOf";

--- a/src/web3/evm/connector/evmWallet/actions/balanceOf.ts
+++ b/src/web3/evm/connector/evmWallet/actions/balanceOf.ts
@@ -1,0 +1,37 @@
+import { ConnectorInput, ConnectorOutput } from "grindery-nexus-common-utils";
+import { getWeb3 } from "../../../web3";
+import { parseUserAccessToken } from "../../../../../jwt";
+
+export async function getBalanceNative(input: ConnectorInput<unknown>): Promise<ConnectorOutput> {
+  const fields = input.fields as {
+    [key: string]: string | { address: string };
+  };
+
+  if (!(fields as { [key: string]: string })._grinderyUserToken) {
+    console.warn("_grinderyUserToken is not available");
+  }
+  const user = await parseUserAccessToken(
+    (fields as { [key: string]: string })._grinderyUserToken || (fields as { [key: string]: string }).userToken || ""
+  ).catch(() => null);
+  if (!user) {
+    throw new Error("User token is invalid");
+  }
+
+  const { web3 } = getWeb3((fields as { [key: string]: string }).chain);
+
+  return {
+    key: input.key,
+    sessionId: input.sessionId,
+    payload: {
+      balance: await web3.eth
+        .getBalance(
+          (
+            fields.parameters as {
+              address: string;
+            }
+          ).address
+        )
+        .then((result) => web3.utils.fromWei(result)),
+    },
+  };
+}

--- a/src/web3/evm/connector/evmWallet/index.ts
+++ b/src/web3/evm/connector/evmWallet/index.ts
@@ -1,0 +1,1 @@
+export * from "./actions/balanceOf";

--- a/src/web3/evm/connector/syndicate/actions/investmentClubInformation.ts
+++ b/src/web3/evm/connector/syndicate/actions/investmentClubInformation.ts
@@ -1,0 +1,82 @@
+import { ActionOutput, ConnectorInput } from "grindery-nexus-common-utils";
+import { callSmartContract } from "../../../call";
+import { sanitizeParameters } from "../../../../../utils";
+import { ethers } from "ethers";
+
+export async function InformationInvestmentClub(input: ConnectorInput<unknown>): Promise<ActionOutput> {
+  const fields = input.fields as {
+    [key: string]: string;
+  };
+
+  const getOwner = await callSmartContract(
+    await sanitizeParameters({
+      ...input,
+      fields: {
+        ...fields,
+        functionDeclaration: "function owner() view returns (address)",
+        parameters: {},
+      },
+    })
+  );
+
+  const getName = await callSmartContract(
+    await sanitizeParameters({
+      ...input,
+      fields: {
+        ...fields,
+        functionDeclaration: "function name() view returns (string)",
+        parameters: {},
+      },
+    })
+  );
+
+  const getSymbol = await callSmartContract(
+    await sanitizeParameters({
+      ...input,
+      fields: {
+        ...fields,
+        functionDeclaration: "function symbol() view returns (string)",
+        parameters: {},
+      },
+    })
+  );
+
+  const getTotalSupply = await callSmartContract(
+    await sanitizeParameters({
+      ...input,
+      fields: {
+        ...fields,
+        functionDeclaration: "function totalSupply() view returns (uint256)",
+        parameters: {},
+      },
+    })
+  );
+
+  return {
+    ...getTotalSupply,
+    payload: {
+      owner: (
+        getOwner.payload as {
+          returnValue: string;
+        }
+      ).returnValue,
+      name: (
+        getName.payload as {
+          returnValue: string;
+        }
+      ).returnValue,
+      symbol: (
+        getSymbol.payload as {
+          returnValue: string;
+        }
+      ).returnValue,
+      totalSupply: ethers.utils.formatEther(
+        (
+          getTotalSupply.payload as {
+            returnValue: string;
+          }
+        ).returnValue
+      ),
+    },
+  };
+}

--- a/src/web3/evm/connector/syndicate/index.ts
+++ b/src/web3/evm/connector/syndicate/index.ts
@@ -1,0 +1,1 @@
+export * from "./actions/investmentClubInformation";


### PR DESCRIPTION
Until now, several particular cases of actions (ERC20, Syndicate...) were present with if conditions inside the `callSmartContract` function.

For more clarity and for a scalable approach, these special cases are moved to dedicated and separate folders.

Should solve #63.