### PR TITLE
feat(evm): removing `any` types in Chainlink actions

### DIFF
--- a/src/web3/evm/connector/chainlink/action.ts
+++ b/src/web3/evm/connector/chainlink/action.ts
@@ -37,7 +37,13 @@ export async function clkPriceFeedAction(input: ConnectorInput<unknown>): Promis
       },
     })
   );
-  const decimals = new BigNumber((getDecimals.payload as any).returnValue);
+  const decimals = new BigNumber(
+    (
+      getDecimals.payload as {
+        returnValue: string;
+      }
+    ).returnValue
+  );
   /* Getting the pair from the smart contract. */
   const getPair = await callSmartContract(
     await sanitizeParameters({
@@ -66,10 +72,20 @@ export async function clkPriceFeedAction(input: ConnectorInput<unknown>): Promis
   );
   /* Converting the exchange rate from the smart contract to a human readable format. */
   res.payload = {
-    _exchangeRate: new BigNumber((res.payload as any).returnValue.return1)
+    _exchangeRate: new BigNumber(
+      (
+        res.payload as {
+          [key: string]: { [key: string]: string };
+        }
+      ).returnValue.return1
+    )
       .div(new BigNumber(10).pow(decimals))
       .toString(),
-    _pair: (getPair.payload as any).returnValue,
+    _pair: (
+      getPair.payload as {
+        returnValue: string;
+      }
+    ).returnValue,
     _contractAddress: contractAddr,
   };
   return res;

--- a/src/web3/evm/connector/chainlink/common.ts
+++ b/src/web3/evm/connector/chainlink/common.ts
@@ -41,13 +41,11 @@ async function getPairs(feed: string): Promise<FieldChoiceSchema[]> {
       if (item.feedCategory === "verified" || !item.feedCategory) {
         pairsArray.push({
           value: item.name.concat(" - ", item.proxyAddress),
-          // .concat(" - decimals:", item.decimals),
           label: item.name,
           sample: item.name,
         });
       }
     });
-    // console.log(pairsArray);
     return pairsArray;
   } catch (err) {
     throw new Error(err);
@@ -61,7 +59,6 @@ async function getPairs(feed: string): Promise<FieldChoiceSchema[]> {
  * @returns A string
  */
 export async function extractAddressFromPair(input?: string): Promise<string> {
-  console.log("inpuuuuuut", input);
   if (!input) {
     return "";
   }

--- a/src/web3/evm/connector/chainlink/common.ts
+++ b/src/web3/evm/connector/chainlink/common.ts
@@ -3,25 +3,25 @@ import { FieldSchema, FieldChoiceSchema } from "grindery-nexus-common-utils/dist
 import axios from "axios";
 
 export type clkFields = {
-    _grinderyChain?: string;
-    _getChainlinkPriceFeed?: string;
+  _grinderyChain?: string;
+  _getChainlinkPriceFeed?: string;
 };
 
 /* A mapping of the chain ID to the feed name. */
-const CHAINS_MAPPING_CHAINLINK_PRICE_FEEDS : {[key: string]: string} = {
-    "eip155:1": "mainnet",
-    "eip155:42161": "ethereum-mainnet-arbitrum-1",
-    "eip155:100": "xdai-mainnet",
-    "eip155:137": "matic-mainnet",
-    "eip155:42220": "",
-    "eip155:43114": "avalanche-mainnet",
-    "eip155:56": "bsc-mainnet",
-    "eip155:250": "fantom-mainnet",
-    "eip155:1666600000": "harmony-mainnet-0",
-    "eip155:80001": "matic-testnet",
-    "eip155:5": "goerli",
-    "eip155:97": "bsc-testnet",
-    "eip155:25": "",
+const CHAINS_MAPPING_CHAINLINK_PRICE_FEEDS: { [key: string]: string } = {
+  "eip155:1": "mainnet",
+  "eip155:42161": "ethereum-mainnet-arbitrum-1",
+  "eip155:100": "xdai-mainnet",
+  "eip155:137": "matic-mainnet",
+  "eip155:42220": "",
+  "eip155:43114": "avalanche-mainnet",
+  "eip155:56": "bsc-mainnet",
+  "eip155:250": "fantom-mainnet",
+  "eip155:1666600000": "harmony-mainnet-0",
+  "eip155:80001": "matic-testnet",
+  "eip155:5": "goerli",
+  "eip155:97": "bsc-testnet",
+  "eip155:25": "",
 };
 
 /**
@@ -34,25 +34,24 @@ const CHAINS_MAPPING_CHAINLINK_PRICE_FEEDS : {[key: string]: string} = {
  * - sample: string
  */
 async function getPairs(feed: string): Promise<FieldChoiceSchema[]> {
-    const pairsArray = [] as FieldChoiceSchema[];
-    try {
-        const res = await axios.get(`https://reference-data-directory.vercel.app/feeds-${feed}.json`);
-        res.data.map(item => {
-            if (item.feedCategory === "verified" || !item.feedCategory) {
-                pairsArray.push({
-                    value: item.name
-                    .concat(" - ", item.proxyAddress),
-                    // .concat(" - decimals:", item.decimals),
-                    label: item.name,
-                    sample: item.name
-                });
-            }
+  const pairsArray = [] as FieldChoiceSchema[];
+  try {
+    const res = await axios.get(`https://reference-data-directory.vercel.app/feeds-${feed}.json`);
+    res.data.map((item) => {
+      if (item.feedCategory === "verified" || !item.feedCategory) {
+        pairsArray.push({
+          value: item.name.concat(" - ", item.proxyAddress),
+          // .concat(" - decimals:", item.decimals),
+          label: item.name,
+          sample: item.name,
         });
-        // console.log(pairsArray);
-        return pairsArray;
-    } catch (err) {
-        throw new Error(err);
-    }
+      }
+    });
+    // console.log(pairsArray);
+    return pairsArray;
+  } catch (err) {
+    throw new Error(err);
+  }
 }
 
 /**
@@ -62,18 +61,19 @@ async function getPairs(feed: string): Promise<FieldChoiceSchema[]> {
  * @returns A string
  */
 export async function extractAddressFromPair(input?: string): Promise<string> {
-    if (!input) {
-        return "";
-    }
-    const hexStart = input.indexOf("0x");
-    if (hexStart === -1) {
-        return "";
-    }
-    const hexEnd = input.indexOf(" ", hexStart);
-    if (hexEnd === -1) {
-        return input.substring(hexStart);
-    }
-    return input.substring(hexStart, hexEnd);
+  console.log("inpuuuuuut", input);
+  if (!input) {
+    return "";
+  }
+  const hexStart = input.indexOf("0x");
+  if (hexStart === -1) {
+    return "";
+  }
+  const hexEnd = input.indexOf(" ", hexStart);
+  if (hexEnd === -1) {
+    return input.substring(hexStart);
+  }
+  return input.substring(hexStart, hexEnd);
 }
 
 /**
@@ -81,31 +81,29 @@ export async function extractAddressFromPair(input?: string): Promise<string> {
  * @param {CommonFields} fieldData - CommonFields
  * @returns an object of type InputProviderOutput.
  */
-export async function prepareOutputChainlink(fieldData: clkFields): Promise<InputProviderOutput>  {
-    /* Creating a new object called ret and assigning it the type InputProviderOutput. */
-    const ret: InputProviderOutput = {
-      inputFields: [
-        {
-          key: "_grinderyChain",
-          required: true,
-          type: "string",
-          label: "Blockchain",
-        }
-      ],
-    };
-    /* Checking if the fieldData object has a property called _grinderyChain. If it does, it will add a
+export async function prepareOutputChainlink(fieldData: clkFields): Promise<InputProviderOutput> {
+  /* Creating a new object called ret and assigning it the type InputProviderOutput. */
+  const ret: InputProviderOutput = {
+    inputFields: [
+      {
+        key: "_grinderyChain",
+        required: true,
+        type: "string",
+        label: "Blockchain",
+      },
+    ],
+  };
+  /* Checking if the fieldData object has a property called _grinderyChain. If it does, it will add a
     new field to the inputFields array. */
-    if (fieldData?._grinderyChain) {
-        ret.inputFields.push({
-            key: "_getChainlinkPriceFeed",
-            label: "Chainlink Price Feed",
-            type: "string",
-            required: true,
-            placeholder: "Select a pair",
-            choices: await getPairs(
-                CHAINS_MAPPING_CHAINLINK_PRICE_FEEDS[fieldData._grinderyChain]
-            )
-        } as FieldSchema);
-    }
-    return ret;
+  if (fieldData?._grinderyChain) {
+    ret.inputFields.push({
+      key: "_getChainlinkPriceFeed",
+      label: "Chainlink Price Feed",
+      type: "string",
+      required: true,
+      placeholder: "Select a pair",
+      choices: await getPairs(CHAINS_MAPPING_CHAINLINK_PRICE_FEEDS[fieldData._grinderyChain]),
+    } as FieldSchema);
+  }
+  return ret;
 }


### PR DESCRIPTION
The Chainlink actions code contained `any` types in several places, which gave linter warnings on the one hand and behavior that could be unsafe for the code.

This PR contains:
- Indicating the correct types rather than `any` in Chainlink actions main file.
- Formatting update for `common.ts` file in Chainlink connector.
- Removing unnecessary `console.log` instances.