### PR TITLE
refactor(evm): refactoring evm functions and ABI imports

### DIFF
--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -1,10 +1,10 @@
 import { ConnectorInput, ConnectorOutput } from "grindery-nexus-common-utils/dist/connector";
-import { TransactionConfig, TransactionReceipt } from "web3-core";
+import { TransactionConfig } from "web3-core";
 import { getUserAddress, parseFunctionDeclaration, HUB_ADDRESS } from "./utils";
 import { getWeb3 } from "./web3";
 import { encodeExecTransaction, execTransactionAbi } from "./gnosisSafe";
 import { parseUserAccessToken } from "../../jwt";
-import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import axios, { AxiosResponse } from "axios";
 import Web3 from "web3";
 import mutexify from "mutexify/promise";
 import { BigNumber } from "@ethersproject/bignumber";

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -362,16 +362,6 @@ export async function callSmartContract(
         }
       }
 
-      if (functionInfo.name === "mintNFT" || functionInfo.name === "mintNFTs") {
-        return {
-          key: input.key,
-          sessionId: input.sessionId,
-          payload: {
-            transactionHash: (result as TransactionReceipt).transactionHash,
-          },
-        };
-      }
-
       return {
         key: input.key,
         sessionId: input.sessionId,

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -338,18 +338,16 @@ export async function callSmartContract(
             throw new Error("No transaction result log in receipt");
           }
           const resultData = web3.eth.abi.decodeLog(eventAbi?.inputs || [], log.data, log.topics.slice(1));
-          if (resultData.success) {
-            if (functionInfo.outputs?.length) {
-              callResultDecoded = web3.eth.abi.decodeParameters(functionInfo.outputs || [], resultData.returnData);
-              if (functionInfo.outputs.length === 1) {
-                callResultDecoded = callResultDecoded[0];
-              }
-              result = {
-                ...receipt,
-                returnValue: callResultDecoded,
-                contractAddress: input.fields.contractAddress,
-              };
+          if (resultData.success && functionInfo.outputs?.length) {
+            callResultDecoded = web3.eth.abi.decodeParameters(functionInfo.outputs || [], resultData.returnData);
+            if (functionInfo.outputs.length === 1) {
+              callResultDecoded = callResultDecoded[0];
             }
+            result = {
+              ...receipt,
+              returnValue: callResultDecoded,
+              contractAddress: input.fields.contractAddress,
+            };
           } else {
             throw new Error("Unexpected failure: " + resultData.returnData);
           }

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -232,8 +232,7 @@ export async function callSmartContract(
           },
         };
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      txConfig.nonce = web3.utils.toHex(await web3.eth.getTransactionCount(web3.defaultAccount)) as any;
+      txConfig.nonce = await web3.eth.getTransactionCount(web3.defaultAccount);
       let result: unknown;
       for (const key of ["gasLimit", "maxFeePerGas", "maxPriorityFeePerGas"]) {
         if (key in input.fields && typeof input.fields[key] === "string") {
@@ -334,10 +333,7 @@ export async function callSmartContract(
 
         if (droneAddress) {
           const eventAbi = GrinderyNexusDrone.find((x) => x.name === "TransactionResult");
-          const eventSignature = web3.eth.abi.encodeEventSignature(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            eventAbi as any
-          );
+          const eventSignature = web3.eth.abi.encodeEventSignature(eventAbi as AbiItem);
           const log = receipt.logs.find((x) => x.topics?.[0] === eventSignature && x.address === droneAddress);
           if (!log) {
             throw new Error("No transaction result log in receipt");

--- a/src/web3/evm/connector/gnosisSafe/triggers/deposit.ts
+++ b/src/web3/evm/connector/gnosisSafe/triggers/deposit.ts
@@ -25,8 +25,7 @@ export async function safeDepositReceivedNative(input: ConnectorInput): Promise<
   return ret;
 }
 export async function safeDepositReceivedERC20(input: ConnectorInput): Promise<TriggerBase> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  input = (await sanitizeParameters(input)) as any;
+  input = await sanitizeParameters(input);
   const ret = new evm.NewEventTrigger(
     await sanitizeParameters({
       ...input,

--- a/src/web3/evm/index.ts
+++ b/src/web3/evm/index.ts
@@ -4,6 +4,7 @@ import { NewTransactionTrigger, NewEventTrigger } from "./triggers";
 import { getUserAddress, HUB_ADDRESS } from "./utils";
 import { getWeb3 } from "./web3";
 import GrinderyNexusHub from "./abi/GrinderyNexusHub.json";
+import { AbiItem } from "web3-utils";
 
 export { callSmartContract } from "./call";
 
@@ -20,8 +21,7 @@ export async function getUserDroneAddress(user: TAccessToken) {
   if (!droneAddressCache.has(userAddress)) {
     const { web3, close } = getWeb3("eip155:1");
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const hubContract = new web3.eth.Contract(GrinderyNexusHub as any, HUB_ADDRESS);
+      const hubContract = new web3.eth.Contract(GrinderyNexusHub as AbiItem[], HUB_ADDRESS);
       const droneAddress = await hubContract.methods.getUserDroneAddress(userAddress).call();
       droneAddressCache.set(userAddress, droneAddress);
     } finally {

--- a/src/web3/evm/unitConverter.ts
+++ b/src/web3/evm/unitConverter.ts
@@ -2,6 +2,7 @@ import BN from "bn.js";
 import Web3 from "web3";
 import { getWeb3 } from "./web3";
 import ERC20 from "./abi/ERC20.json";
+import { AbiItem } from "web3-utils";
 
 const ERC20_DECIMALS_ABI = ERC20.find((item) => item.name === "decimals");
 
@@ -23,12 +24,12 @@ function numberToString(arg: any) {
 }
 
 function scaleDecimals(etherInput: string, decimals: number) {
-  let ether = numberToString(etherInput); // eslint-disable-line
+  let ether = numberToString(etherInput);
   const base = new BN(10).pow(new BN(decimals));
   const baseLength = base.toString(10).length - 1;
 
   // Is it negative?
-  const negative = ether.substring(0, 1) === "-"; // eslint-disable-line
+  const negative = ether.substring(0, 1) === "-";
   if (negative) {
     ether = ether.substring(1);
   }
@@ -38,13 +39,13 @@ function scaleDecimals(etherInput: string, decimals: number) {
   }
 
   // Split it into a whole and fractional part
-  const comps = ether.split("."); // eslint-disable-line
+  const comps = ether.split(".");
   if (comps.length > 2) {
     throw new Error(`[ethjs-unit] while converting number ${etherInput} to wei,  too many decimal points`);
   }
 
   let whole = comps[0],
-    fraction = comps[1]; // eslint-disable-line
+    fraction = comps[1];
 
   if (!whole) {
     whole = "0";
@@ -62,7 +63,7 @@ function scaleDecimals(etherInput: string, decimals: number) {
 
   whole = new BN(whole);
   fraction = new BN(fraction);
-  var wei = whole.mul(base).add(fraction); // eslint-disable-line
+  let wei = whole.mul(base).add(fraction);
 
   if (negative) {
     wei = wei.mul(new BN(-1));
@@ -104,8 +105,7 @@ const UNIT_CONVERTERS: [
       const { web3, close } = getWeb3(fields.chain as string);
       let decimals: number;
       try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const contract = new web3.eth.Contract(ERC20_DECIMALS_ABI as any, contractAddress);
+        const contract = new web3.eth.Contract(ERC20_DECIMALS_ABI as AbiItem, contractAddress);
         decimals = await contract.methods.decimals().call({ from: contractAddress });
       } finally {
         close();
@@ -116,7 +116,6 @@ const UNIT_CONVERTERS: [
   [
     /^([^-]+)->wei$/,
     async (value: unknown, m: RegExpMatchArray) => {
-      // console.log(String(value));
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return Web3.utils.toWei(String(value), m[1] as any);
     },

--- a/src/web3/evm/unitConverter.ts
+++ b/src/web3/evm/unitConverter.ts
@@ -1,18 +1,9 @@
 import BN from "bn.js";
 import Web3 from "web3";
 import { getWeb3 } from "./web3";
+import ERC20 from "./abi/ERC20.json";
 
-const ERC20_DECIMALS_ABI = [
-  {
-    constant: true,
-    inputs: [],
-    name: "decimals",
-    outputs: [{ name: "", type: "uint8" }],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-];
+const ERC20_DECIMALS_ABI = ERC20.find((item) => item.name === "decimals");
 
 // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
 function numberToString(arg: any) {


### PR DESCRIPTION
This PR contains the following items:
- Always import ABIs from the dedicated `abi` folder.
- Removing unused imports in `call.ts` file.
- Always use `AbiItem` type when possible instead of `any`.
- Simplify some code snippet in `callSmartContract`.
- Making linter happy with types.