### PR TITLE
feat(unitConverter): restrict the usage of `numberToString` function

### DIFF
--- a/src/web3/evm/unitConverter.ts
+++ b/src/web3/evm/unitConverter.ts
@@ -14,21 +14,13 @@ const ERC20_DECIMALS_ABI = [
   },
 ];
 
-// trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
-function numberToString(arg: any) {
-  if (typeof arg === "string") {
-    if (!arg.match(/^-?[0-9.]+$/)) {
-      throw new Error(
-        `while converting number to string, invalid number value '${arg}', should be a number matching (^-?[0-9.]+).`
-      );
-    }
-    return arg;
-  } else if (typeof arg === "number") {
-    return String(arg);
-  } else if (typeof arg === "object" && arg.toString && (arg.toTwos || arg.dividedToIntegerBy)) {
-    return arg.toPrecision ? String(arg.toPrecision()) : arg.toString(10);
+function numberToString(arg: string) {
+  if (!arg.match(/^-?[0-9.]+$/)) {
+    throw new Error(
+      `while converting number to string, invalid number value '${arg}', should be a number matching (^-?[0-9.]+).`
+    );
   }
-  throw new Error(`while converting number to string, invalid number value '${arg}' type ${typeof arg}.`);
+  return arg;
 }
 
 function scaleDecimals(etherInput: string, decimals: number) {


### PR DESCRIPTION
`numberToString` usage, in `unitConverter.ts` file, is restricted to `string` type inputs.

Should solve #79.