### PR TITLE
refactor(utils): remove unused `isJson` function

### DIFF
--- a/src/web3/utils.ts
+++ b/src/web3/utils.ts
@@ -37,15 +37,3 @@ export type AlgorandDepayActions = {
   userAccount: algosdk.Account;
   receiver: string;
 };
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isJson(item: any): boolean {
-  item = typeof item !== "string" ? JSON.stringify(item) : item;
-  try {
-    item = JSON.parse(item);
-  } catch (e) {
-    return false;
-  }
-
-  return typeof item === "object" && item !== null;
-}


### PR DESCRIPTION
The util `isJson` function is declared but never used. Also, I think it can be replaced by a simple test with `JSON.parse`. In order to keep the code clean, this function can be removed.