### PR TITLE
refactor(utils): refactor `isSameAddress` function

### DIFF
--- a/src/web3/evm/utils.ts
+++ b/src/web3/evm/utils.ts
@@ -56,14 +56,8 @@ export function onNewBlockMultiChain(
     cleanUpFunctions.splice(0, cleanUpFunctions.length);
   };
 }
-export function isSameAddress(a, b) {
-  if (!a || !b) {
-    return false;
-  }
-  if (/^0x/.test(a) && /^0x/.test(b)) {
-    return a.toLowerCase() === b.toLowerCase();
-  }
-  return a === b;
+export function isSameAddress(a: string | null, b: string | null): boolean {
+  return !!a && !!b && (/^0x/.test(a) && /^0x/.test(b) ? a.toLowerCase() === b.toLowerCase() : a === b);
 }
 export function parseEventDeclaration(eventDeclaration: string): AbiItem {
   const m = /^\s*(event +)?([a-zA-Z0-9_]+)\s*\(([^)]+)\)\s*;?\s*$/.exec(eventDeclaration);


### PR DESCRIPTION
`isSameAddress` util function is always called with arguments that are either `string` in the general case or `string | null` if the following `transaction` type is used:

```typescript
export interface Transaction {
     hash: string;
     nonce: number;
     blockHash: string | null;
     blockNumber: number | null;
     transactionIndex: number | null;
     from: string;
     to: string | null;
     value: string;
     gasPrice: string;
     maxPriorityFeePerGas?: number | thong | BN;
     maxFeePerGas?: number | thong | BN;
     gas: number;
     input: string;
}
```
Therefore, one can enforce a more restrictive typing to be sure that the inserted arguments are only `strings` or `null`.

I also took the opportunity to slightly refactor the function without changing its operation.