### PR TITLE
refactor(non-null-assertion): making linter happy with `no-non-null-assertion`

### DIFF
--- a/src/vaultAgent.ts
+++ b/src/vaultAgent.ts
@@ -4,8 +4,7 @@ import { JSONRPCRequest, JSONRPCResponse } from "json-rpc-2.0";
 const auth = new GoogleAuth();
 let client: OAuth2Client;
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const VAULT_AGENT_URL = process.env.VAULT_AGENT_URL!;
+const VAULT_AGENT_URL = process.env.VAULT_AGENT_URL || "";
 
 async function getClient() {
   if (!client) {

--- a/src/web3/algorand/algorand.ts
+++ b/src/web3/algorand/algorand.ts
@@ -404,8 +404,7 @@ export async function callSmartContract(
 
   // Get user account
   const userAccount = await getUserAccountAlgorand(user);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const grinderyAccount = algosdk.mnemonicToSecretKey(process.env.ALGORAND_MNEMONIC_GRINDERY!);
+  const grinderyAccount = algosdk.mnemonicToSecretKey(process.env.ALGORAND_MNEMONIC_GRINDERY || "");
 
   // Set new atomicTransactionComposer
   const comp = new algosdk.AtomicTransactionComposer();

--- a/src/web3/algorand/contracts/deploy.ts
+++ b/src/web3/algorand/contracts/deploy.ts
@@ -1,30 +1,23 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-// import * as dotenv from "dotenv";
 import algosdk from "algosdk";
-import { TextEncoder } from "util";
 import { open } from "node:fs/promises";
 import "dotenv/config";
 
 const baseServer = "https://testnet-algorand.api.purestake.io/ps2";
 const port = "";
 const token = {
-  "X-API-Key": process.env.ALGORAND_API_KEY!,
+  "X-API-Key": process.env.ALGORAND_API_KEY || "",
 };
 
 const algodClient = new algosdk.Algodv2(token, baseServer, port);
 
-const myaccount = algosdk.mnemonicToSecretKey(process.env.ALGORAND_MNEMONIC!);
+const myaccount = algosdk.mnemonicToSecretKey(process.env.ALGORAND_MNEMONIC || "");
 const sender = myaccount.addr;
 
 // helper function to compile program source
-async function compileProgram(client: any, TealSource: any) {
-  const encoder = new TextEncoder();
-  const programBytes = encoder.encode(TealSource);
+async function compileProgram(client: algosdk.Algodv2, TealSource: Buffer) {
+  const programBytes = new Uint8Array(TealSource.buffer);
   const compileResponse = await client.compile(programBytes).do();
-  const compiledBytes = new Uint8Array(
-    Buffer.from(compileResponse.result, "base64")
-  );
+  const compiledBytes = new Uint8Array(Buffer.from(compileResponse.result, "base64"));
   return compiledBytes;
 }
 
@@ -35,20 +28,13 @@ async function compileProgram(client: any, TealSource: any) {
     const globalInts = 1;
     const globalBytes = 0;
 
-    const approvalProgramfile = await open(
-      "./src/web3/algorand/contracts/txntest/approval.teal"
-    );
-    const clearProgramfile = await open(
-      "./src/web3/algorand/contracts/txntest/clear.teal"
-    );
+    const approvalProgramfile = await open("./src/web3/algorand/contracts/txntest/approval.teal");
+    const clearProgramfile = await open("./src/web3/algorand/contracts/txntest/clear.teal");
 
     const approvalProgram = await approvalProgramfile.readFile();
     const clearProgram = await clearProgramfile.readFile();
 
-    const approvalProgramBinary = await compileProgram(
-      algodClient,
-      approvalProgram
-    );
+    const approvalProgramBinary = await compileProgram(algodClient, approvalProgram);
     const clearProgramBinary = await compileProgram(algodClient, clearProgram);
 
     const params = await algodClient.getTransactionParams().do();
@@ -80,9 +66,7 @@ async function compileProgram(client: any, TealSource: any) {
     await algosdk.waitForConfirmation(algodClient, txId, 2);
 
     // print the app-id
-    const transactionResponse = await algodClient
-      .pendingTransactionInformation(txId)
-      .do();
+    const transactionResponse = await algodClient.pendingTransactionInformation(txId).do();
     const appId = transactionResponse["application-index"];
     console.log("Created new with app-id: ", appId);
   } catch (err) {

--- a/src/web3/algorand/txtestalgorand.ts
+++ b/src/web3/algorand/txtestalgorand.ts
@@ -43,22 +43,19 @@ export async function SendTransactionAction(
   };
 
   depay.fields.comp.addMethodCall({
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    appID: Number(process.env.ALGORAND_APP_ID!),
+    appID: Number(process.env.ALGORAND_APP_ID || ""),
     method: parseFunctionDeclarationAlgorand(input.fields.functionDeclaration),
     // method: test,
     methodArgs: [
       0,
       {
         txn: new Transaction({
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          from: depay.fields.grinderyAccount.addr!,
+          from: depay.fields.grinderyAccount.addr,
           to: depay.fields.receiver,
           amount: 0,
           ...spNoFee,
         }),
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        signer: algosdk.makeBasicAccountTransactionSigner(depay.fields.grinderyAccount!),
+        signer: algosdk.makeBasicAccountTransactionSigner(depay.fields.grinderyAccount),
       },
       0,
     ],

--- a/src/web3/algorand/utils.ts
+++ b/src/web3/algorand/utils.ts
@@ -63,8 +63,7 @@ export async function getAlgodClient(chain: string) {
   const networkId = await getNetworkId(chain);
   const baseServer = `https://${networkId}-algorand.api.purestake.io/ps2`;
   const port = "";
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const token = { "X-API-Key": process.env.ALGORAND_API_KEY! };
+  const token = { "X-API-Key": process.env.ALGORAND_API_KEY || "" };
 
   return new algosdk.Algodv2(token, baseServer, port);
 }

--- a/src/web3/flow/index.ts
+++ b/src/web3/flow/index.ts
@@ -82,8 +82,7 @@ export async function callSmartContract(
 export async function createAccount() {
   return await _createAccount({
     senderArgs: {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      accountAddress: process.env.FLOW_PROPOSER_ADDRESS!,
+      accountAddress: process.env.FLOW_PROPOSER_ADDRESS || "",
       keyId: 0,
     },
     payerArgs: {

--- a/src/web3/flow/triggers.ts
+++ b/src/web3/flow/triggers.ts
@@ -350,8 +350,11 @@ function getSubscriber(contractAddress: string): ContractSubscriber {
   if (!subscribers.has(contractAddress)) {
     subscribers.set(contractAddress, new ContractSubscriber(contractAddress));
   }
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return subscribers.get(contractAddress)!;
+  const subscriber = subscribers.get(contractAddress);
+  if (subscriber === undefined) {
+    throw new Error(`Subscriber not found for contract address: ${contractAddress}`);
+  }
+  return subscriber;
 }
 /* It subscribes to the `TokensDeposited` and `TokensWithdrawn` events of the `FlowToken` contract, and
 sends a notification for each event that matches the `from` and `to` parameters */

--- a/src/web3/near/near.ts
+++ b/src/web3/near/near.ts
@@ -373,12 +373,7 @@ export async function callSmartContract(
   await keyStore.setKey(networkId, CONTRACT_NAME, KeyPair.fromString(process.env.PRIVATE_KEY as string));
 
   // Get grindery account
-  const grinderyAccount = await nearGetAccount(
-    input.fields.chain,
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    process.env.NEAR_ACCOUNT_ID!,
-    keyStore
-  );
+  const grinderyAccount = await nearGetAccount(input.fields.chain, process.env.NEAR_ACCOUNT_ID || "", keyStore);
 
   // Get user key pair
   const seed = (await hmac("grindery-near-key/" + user.sub)).subarray(0, 32);


### PR DESCRIPTION
In order to secure the codebase, this PR contains:
- Removing the `eslint-disable-next-line @typescript-eslint/no-non-null-assertion` constraint favoring a safer approach.
- Removing non used imports in `src/web3/algorand/contracts/deploy.ts`