### PR TITLE
refactor(await): removing `await` with no effect

### DIFF
--- a/src/web3/near.ts
+++ b/src/web3/near.ts
@@ -271,7 +271,7 @@ class ReceiptSubscriber extends EventEmitter {
    */
   subscribe({ callback, onError }: { callback: (receipt: Receipt) => void; onError: (error: unknown) => void }) {
     const handler = async (receipt: Receipt) => {
-      await callback(receipt);
+      callback(receipt);
     };
     const errorHandler = (error: unknown) => {
       onError(error);

--- a/src/web3/near/near.ts
+++ b/src/web3/near/near.ts
@@ -384,7 +384,7 @@ export async function callSmartContract(
   const seed = (await hmac("grindery-near-key/" + user.sub)).subarray(0, 32);
   const newkeypairtmp = nacl.sign.keyPair.fromSeed(seed);
   const newKeyPair = new utils.KeyPairEd25519(base_encode(newkeypairtmp.secretKey));
-  const newPublicKey = await newKeyPair.getPublicKey();
+  const newPublicKey = newKeyPair.getPublicKey();
 
   // Get user implicit account from the new key pair
   const implicit_user_id = Buffer.from(utils.PublicKey.fromString(newPublicKey.toString()).data).toString("hex");
@@ -399,7 +399,7 @@ export async function callSmartContract(
   } catch (e) {
     // If ueser account doens't exist, then create an implicit grinderyAccount via transaction
     if (e.type === "AccountDoesNotExist") {
-      await grinderyAccount.sendMoney(implicit_user_id, new BN((await utils.format.parseNearAmount("1")) as string));
+      await grinderyAccount.sendMoney(implicit_user_id, new BN(utils.format.parseNearAmount("1") as string));
       console.log("new grinderyAccount created with userID ", implicit_user_id);
     }
   }

--- a/src/web3/near/nftnear.ts
+++ b/src/web3/near/nftnear.ts
@@ -18,10 +18,7 @@ export async function SendTransactionAction(
   depay: DepayActions<NearDepayActions>
 ): Promise<ConnectorOutput> {
   // Make deposit from grindery account to the user account
-  await depay.fields.grinderyAccount.sendMoney(
-    depay.fields.userAccount.accountId,
-    await utils.format.parseNearAmount("0.1")
-  );
+  await depay.fields.grinderyAccount.sendMoney(depay.fields.userAccount.accountId, utils.format.parseNearAmount("0.1"));
 
   // Set arguments for NFT minting
   const args = {
@@ -42,7 +39,7 @@ export async function SendTransactionAction(
         "nft_mint",
         args,
         new BN(10000000000000),
-        new BN((await utils.format.parseNearAmount("0.1")) as string)
+        new BN(utils.format.parseNearAmount("0.1") as string)
       ),
     ],
   });


### PR DESCRIPTION
The codebase contains some `await` which have no effect where they are placed. To clean up the codebase, these `await` are eliminated.