### PR TITLE
feat(test): adding unit tests for `parseEventDeclaration` EVM function

### DIFF
--- a/src/test/evm-utils.test.ts
+++ b/src/test/evm-utils.test.ts
@@ -1,6 +1,6 @@
 import chai from "chai";
 import chaiHttp from "chai-http";
-import { isSameAddress } from "../web3/evm/utils";
+import { isSameAddress, parseEventDeclaration } from "../web3/evm/utils";
 
 /* eslint-disable no-unused-expressions */
 
@@ -30,6 +30,119 @@ describe("EVM utils tests", async function () {
 
     it("Should return false if address A and address B are null", async function () {
       chai.expect(isSameAddress(null, null)).to.be.false;
+    });
+  });
+
+  describe("parseEventDeclaration", async function () {
+    it("Should throw error if name does not appear at the beginning", async function () {
+      chai
+        .expect(() => parseEventDeclaration("(address previousAdmin, address newAdmin);"))
+        .to.throw(Error)
+        .with.property("message", "Invalid event declaration");
+    });
+
+    it("Should render correct event parsing for classical events with ; at the end", async function () {
+      chai.expect(parseEventDeclaration("event AdminChanged(address previousAdmin, address newAdmin);")).to.deep.equal({
+        name: "AdminChanged",
+        inputs: [
+          { indexed: false, type: "address", name: "previousAdmin" },
+          { indexed: false, type: "address", name: "newAdmin" },
+        ],
+        type: "event",
+        anonymous: false,
+      });
+    });
+
+    it("Should render correct event parsing for classical events without ; at the end", async function () {
+      chai.expect(parseEventDeclaration("event AdminChanged(address previousAdmin, address newAdmin)")).to.deep.equal({
+        name: "AdminChanged",
+        inputs: [
+          { indexed: false, type: "address", name: "previousAdmin" },
+          { indexed: false, type: "address", name: "newAdmin" },
+        ],
+        type: "event",
+        anonymous: false,
+      });
+    });
+
+    it("Should render correct event parsing for classical events without event prefix at the beginning", async function () {
+      chai.expect(parseEventDeclaration("AdminChanged(address previousAdmin, address newAdmin)")).to.deep.equal({
+        name: "AdminChanged",
+        inputs: [
+          { indexed: false, type: "address", name: "previousAdmin" },
+          { indexed: false, type: "address", name: "newAdmin" },
+        ],
+        type: "event",
+        anonymous: false,
+      });
+    });
+
+    it("Should render correct event parsing for classical events with random spaces", async function () {
+      chai
+        .expect(parseEventDeclaration("event     AdminChanged (  address   previousAdmin ,   address newAdmin  )  "))
+        .to.deep.equal({
+          name: "AdminChanged",
+          inputs: [
+            { indexed: false, type: "address", name: "previousAdmin" },
+            { indexed: false, type: "address", name: "newAdmin" },
+          ],
+          type: "event",
+          anonymous: false,
+        });
+    });
+
+    it("Should render correct event parsing with arrays", async function () {
+      chai
+        .expect(
+          parseEventDeclaration(
+            "event ExecutedWithSuccess(address[] _assets, uint256[] _amounts, uint256[] _premiums);"
+          )
+        )
+        .to.deep.equal({
+          name: "ExecutedWithSuccess",
+          inputs: [
+            { indexed: false, type: "address[]", name: "_assets" },
+            { indexed: false, type: "uint256[]", name: "_amounts" },
+            { indexed: false, type: "uint256[]", name: "_premiums" },
+          ],
+          type: "event",
+          anonymous: false,
+        });
+    });
+
+    it("Should render correct event parsing with indexed arguments", async function () {
+      chai
+        .expect(parseEventDeclaration("event AssetSourceUpdated(address indexed asset, address indexed source)"))
+        .to.deep.equal({
+          name: "AssetSourceUpdated",
+          inputs: [
+            { indexed: true, type: "address", name: "asset" },
+            { indexed: true, type: "address", name: "source" },
+          ],
+          type: "event",
+          anonymous: false,
+        });
+    });
+
+    it("Should throw error if one parameter type is missing", async function () {
+      chai
+        .expect(() => parseEventDeclaration("event AdminChanged(previousAdmin, address newAdmin)"))
+        .to.throw(Error)
+        .with.property("message", "Invalid event declaration: Invalid parameter previousAdmin");
+    });
+
+    it("Should throw error if one parameter does not have name", async function () {
+      chai
+        .expect(() => parseEventDeclaration("event AdminChanged(address, address newAdmin)"))
+        .to.throw(Error)
+        .with.property("message", "Invalid event declaration: Invalid parameter address");
+    });
+
+    it("Should throw error if one parameter has type + something that is not indexed + name", async function () {
+      chai
+        .expect(() => parseEventDeclaration("event AdminChanged(address not_indexed previousAdmin, address newAdmin)"))
+        .to.throw(Error)
+        .with.property("message", "Invalid event declaration: Invalid parameter address not_indexed previousAdmin");
     });
   });
 });

--- a/src/test/evm-utils.test.ts
+++ b/src/test/evm-utils.test.ts
@@ -41,6 +41,20 @@ describe("EVM utils tests", async function () {
         .with.property("message", "Invalid event declaration");
     });
 
+    it("Should throw error if parenthesis does not appear after event name", async function () {
+      chai
+        .expect(() => parseEventDeclaration("event AdminChanged address previousAdmin, address newAdmin);"))
+        .to.throw(Error)
+        .with.property("message", "Invalid event declaration");
+    });
+
+    it("Should throw error if parenthesis does not appear at the end", async function () {
+      chai
+        .expect(() => parseEventDeclaration("event AdminChanged (address previousAdmin, address newAdmin"))
+        .to.throw(Error)
+        .with.property("message", "Invalid event declaration");
+    });
+
     it("Should render correct event parsing for classical events with ; at the end", async function () {
       chai.expect(parseEventDeclaration("event AdminChanged(address previousAdmin, address newAdmin);")).to.deep.equal({
         name: "AdminChanged",

--- a/src/test/evm-utils.test.ts
+++ b/src/test/evm-utils.test.ts
@@ -140,7 +140,7 @@ describe("EVM utils tests", async function () {
 
     it("Should throw error if one parameter type is missing", async function () {
       chai
-        .expect(() => parseEventDeclaration("event AdminChanged(previousAdmin, address newAdmin)"))
+        .expect(() => parseEventDeclaration("event AdminChanged(   previousAdmin, address newAdmin)"))
         .to.throw(Error)
         .with.property("message", "Invalid event declaration: Invalid parameter previousAdmin");
     });

--- a/src/web3/evm/utils.ts
+++ b/src/web3/evm/utils.ts
@@ -81,7 +81,7 @@ export function parseEventDeclaration(eventDeclaration: string): AbiItem {
         (inputParts.length !== 2 && inputParts.length !== 3) ||
         (inputParts.length === 3 && inputParts[1] !== "indexed")
       ) {
-        throw new Error("Invalid event declaration: Invalid parameter " + p);
+        throw new Error("Invalid event declaration: Invalid parameter " + p.trim());
       }
       return { indexed: inputParts.length === 3, type: inputParts[0], name: inputParts[inputParts.length - 1] };
     }),


### PR DESCRIPTION
This PR contains unit tests to assess the proper implementation of the `parseEventDeclaration` EVM function.

Related #97.