### PR TITLE
feat(refactor): enforce mandatory event prefix in regex

### DIFF
--- a/src/test/evm-utils.test.ts
+++ b/src/test/evm-utils.test.ts
@@ -237,6 +237,13 @@ describe("EVM utils tests", async function () {
   });
 
   describe("parseEventDeclaration", async function () {
+    it("Should throw error if event prefix does not follow event name at the beginning", async function () {
+      chai
+        .expect(() => parseEventDeclaration("event (address previousAdmin, address newAdmin);"))
+        .to.throw(Error)
+        .with.property("message", "Invalid event declaration");
+    });
+
     it("Should throw error if name does not appear at the beginning", async function () {
       chai
         .expect(() => parseEventDeclaration("(address previousAdmin, address newAdmin);"))
@@ -256,6 +263,18 @@ describe("EVM utils tests", async function () {
         .expect(() => parseEventDeclaration("event AdminChanged (address previousAdmin, address newAdmin"))
         .to.throw(Error)
         .with.property("message", "Invalid event declaration");
+    });
+
+    it("Should render correct event parsing for event without event prefix", async function () {
+      chai.expect(parseEventDeclaration("AdminChanged(address previousAdmin, address newAdmin);")).to.deep.equal({
+        name: "AdminChanged",
+        inputs: [
+          { indexed: false, type: "address", name: "previousAdmin" },
+          { indexed: false, type: "address", name: "newAdmin" },
+        ],
+        type: "event",
+        anonymous: false,
+      });
     });
 
     it("Should render correct event parsing for classical events with ; at the end", async function () {

--- a/src/web3/evm/utils.ts
+++ b/src/web3/evm/utils.ts
@@ -68,7 +68,7 @@ export function isSameAddress(a: string | null, b: string | null): boolean {
  * @throws Error if the event declaration is invalid or contains invalid parameters.
  */
 export function parseEventDeclaration(eventDeclaration: string): AbiItem {
-  const eventParts = /^\s*(event +)?([a-zA-Z0-9_]+)\s*\(([^)]+)\)\s*;?\s*$/.exec(eventDeclaration);
+  const eventParts = /^\s*event\s+([a-zA-Z0-9_]+)\s*\(([^)]+)\)\s*;?\s*$/.exec(eventDeclaration);
   if (!eventParts) {
     throw new Error("Invalid event declaration");
   }

--- a/src/web3/evm/utils.ts
+++ b/src/web3/evm/utils.ts
@@ -68,8 +68,13 @@ export function isSameAddress(a: string | null, b: string | null): boolean {
  * @throws Error if the event declaration is invalid or contains invalid parameters.
  */
 export function parseEventDeclaration(eventDeclaration: string): AbiItem {
-  const eventParts = /^\s*event\s+([a-zA-Z0-9_]+)\s*\(([^)]+)\)\s*;?\s*$/.exec(eventDeclaration);
+  const eventParts = /^\s*(event +)?([a-zA-Z0-9_]+)\s*\(([^)]+)\)\s*;?\s*$/.exec(eventDeclaration);
   if (!eventParts) {
+    throw new Error("Invalid event declaration");
+  }
+
+  const eventName = eventParts[2]?.trim();
+  if (eventName === "event") {
     throw new Error("Invalid event declaration");
   }
 


### PR DESCRIPTION
Enforces that the event declaration must start with the word "event" followed by one space, and then the actual event name.

Related to the [issue 103](https://github.com/grindery-io/grindery-nexus-connector-web3/issues/103).

Once this [PR](https://github.com/grindery-io/grindery-nexus-connector-web3/pull/102) is merged I can modify the unit tests and include the refactor changes.