### PR TITLE
feat(refactor): enforce mandatory function prefix in regex

### DIFF
--- a/src/web3/evm/utils.ts
+++ b/src/web3/evm/utils.ts
@@ -97,7 +97,7 @@ export function parseEventDeclaration(eventDeclaration: string): AbiItem {
  * @throws Error if the function declaration is invalid or contains invalid parameters.
  */
 export function parseFunctionDeclaration(functionDeclaration: string): AbiItem {
-  const functionParts = /^\s*(function +)?([a-zA-Z0-9_]+)\s*\(([^)]+)?\)\s*(.*)$/.exec(functionDeclaration);
+  const functionParts = /^\s*function\s+([a-zA-Z0-9_]+)\s*\(([^)]+)?\)\s*(.*)$/.exec(functionDeclaration);
   if (!functionParts) {
     throw new Error("Invalid function declaration");
   }


### PR DESCRIPTION
Ensures that the function declaration must start with the "function" keyword, followed by one space before the actual function name.

Related to the [issue 106](https://github.com/grindery-io/grindery-nexus-connector-web3/issues/106).

Once this [PR](https://github.com/grindery-io/grindery-nexus-connector-web3/pull/102) is merged I can modify the unit tests and include the refactoring changes.