### PR TITLE
feat(test): add unit tests for GnosisSafe `sanitizeInput` function

### DIFF
--- a/src/test/evm/connector/gnosisSafe/index.test.ts
+++ b/src/test/evm/connector/gnosisSafe/index.test.ts
@@ -5,6 +5,7 @@ import axios from "axios";
 import { sanitizeInput } from "../../../../web3/evm/connector/gnosisSafe";
 import { mockedConnectorInput } from "../../../utils";
 import chaiAsPromised from "chai-as-promised";
+import { ConnectorInput } from "grindery-nexus-common-utils";
 
 /* eslint-disable no-unused-expressions */
 
@@ -20,22 +21,28 @@ sinon.stub(axios, "post").resolves(
   })
 );
 
+let connectorInput: ConnectorInput<any>;
+
+before(async () => {
+  connectorInput = await mockedConnectorInput;
+});
+
 describe("Gnosis Safe index test", async function () {
   describe("sanitizeInput", async function () {
     it("Should update chain in input.fields if all parameters are properly set up", async function () {
       const mockedInput = {
-        ...mockedConnectorInput,
+        ...connectorInput,
         fields: {
-          ...mockedConnectorInput.fields,
+          ...connectorInput.fields,
           contractAddress: "0xf7858Da8a6617f7C6d0fF2bcAFDb6D2eeDF64840",
           chainId: "234",
         },
       };
       await sanitizeInput(mockedInput);
       chai.expect(mockedInput).to.deep.equal({
-        ...mockedConnectorInput,
+        ...connectorInput,
         fields: {
-          ...mockedConnectorInput.fields,
+          ...connectorInput.fields,
           contractAddress: "0xf7858Da8a6617f7C6d0fF2bcAFDb6D2eeDF64840",
           chainId: "234",
           chain: "eip155:234",
@@ -45,16 +52,16 @@ describe("Gnosis Safe index test", async function () {
 
     it("Should update chainId in input.fields via _grinderyChain in input.fields", async function () {
       const mockedInput = {
-        ...mockedConnectorInput,
-        authentication: mockedConnectorInput.fields.userToken,
-        fields: { ...mockedConnectorInput.fields, _grinderyChain: "eip155:234" },
+        ...connectorInput,
+        authentication: connectorInput.fields.userToken,
+        fields: { ...connectorInput.fields, _grinderyChain: "eip155:234" },
       };
       await sanitizeInput(mockedInput);
       chai.expect(mockedInput).to.deep.equal({
-        ...mockedConnectorInput,
-        authentication: mockedConnectorInput.fields.userToken,
+        ...connectorInput,
+        authentication: connectorInput.fields.userToken,
         fields: {
-          ...mockedConnectorInput.fields,
+          ...connectorInput.fields,
           chainId: "234",
           chain: "eip155:234",
         },
@@ -63,16 +70,16 @@ describe("Gnosis Safe index test", async function () {
 
     it("Should update chainId in input.fields via API call if _grinderyChain in input.fields is bad formatted", async function () {
       const mockedInput = {
-        ...mockedConnectorInput,
-        authentication: mockedConnectorInput.fields.userToken,
-        fields: { ...mockedConnectorInput.fields, _grinderyChain: "eip15:234" },
+        ...connectorInput,
+        authentication: connectorInput.fields.userToken,
+        fields: { ...connectorInput.fields, _grinderyChain: "eip15:234" },
       };
       await sanitizeInput(mockedInput);
       chai.expect(mockedInput).to.deep.equal({
-        ...mockedConnectorInput,
-        authentication: mockedConnectorInput.fields.userToken,
+        ...connectorInput,
+        authentication: connectorInput.fields.userToken,
         fields: {
-          ...mockedConnectorInput.fields,
+          ...connectorInput.fields,
           contractAddress: "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
           chainId: "123",
           chain: "eip155:123",
@@ -82,10 +89,10 @@ describe("Gnosis Safe index test", async function () {
 
     it("Should update contractAddress in input.fields via _grinderyContractAddress in input.fields", async function () {
       const mockedInput = {
-        ...mockedConnectorInput,
-        authentication: mockedConnectorInput.fields.userToken,
+        ...connectorInput,
+        authentication: connectorInput.fields.userToken,
         fields: {
-          ...mockedConnectorInput.fields,
+          ...connectorInput.fields,
           chainId: "234",
           _grinderyContractAddress: "0x78e79E270eE8B43b15E22a23650Aba749272365B",
         },
@@ -93,10 +100,10 @@ describe("Gnosis Safe index test", async function () {
       delete mockedInput.fields.contractAddress;
       await sanitizeInput(mockedInput);
       chai.expect(mockedInput).to.deep.equal({
-        ...mockedConnectorInput,
-        authentication: mockedConnectorInput.fields.userToken,
+        ...connectorInput,
+        authentication: connectorInput.fields.userToken,
         fields: {
-          ...mockedConnectorInput.fields,
+          ...connectorInput.fields,
           chainId: "234",
           chain: "eip155:234",
           contractAddress: "0x78e79E270eE8B43b15E22a23650Aba749272365B",
@@ -106,8 +113,8 @@ describe("Gnosis Safe index test", async function () {
 
     it("Should throw an error if no authentication provided and contractAddress is not in input.fields", async function () {
       const mockedInput = {
-        ...mockedConnectorInput,
-        fields: { ...mockedConnectorInput.fields, chainId: "234" },
+        ...connectorInput,
+        fields: { ...connectorInput.fields, chainId: "234" },
       };
       delete mockedInput.fields.contractAddress;
       await chai
@@ -118,17 +125,17 @@ describe("Gnosis Safe index test", async function () {
 
     it("Should set contractAddress and chainId from API call if contractAddress is not in input.fields", async function () {
       const mockedInput = {
-        ...mockedConnectorInput,
-        authentication: mockedConnectorInput.fields.userToken,
-        fields: { ...mockedConnectorInput.fields, chainId: "234" },
+        ...connectorInput,
+        authentication: connectorInput.fields.userToken,
+        fields: { ...connectorInput.fields, chainId: "234" },
       };
       delete mockedInput.fields.contractAddress;
       await sanitizeInput(mockedInput);
       chai.expect(mockedInput).to.deep.equal({
-        ...mockedConnectorInput,
-        authentication: mockedConnectorInput.fields.userToken,
+        ...connectorInput,
+        authentication: connectorInput.fields.userToken,
         fields: {
-          ...mockedConnectorInput.fields,
+          ...connectorInput.fields,
           contractAddress: "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
           chain: "eip155:123",
           chainId: "123",
@@ -140,7 +147,7 @@ describe("Gnosis Safe index test", async function () {
       await chai
         .expect(
           sanitizeInput({
-            ...mockedConnectorInput,
+            ...connectorInput,
           })
         )
         .to.eventually.be.rejected.and.be.an.instanceOf(Error)
@@ -149,15 +156,15 @@ describe("Gnosis Safe index test", async function () {
 
     it("Should set contractAddress and chainId from API call if chainId is not in input.fields", async function () {
       const mockedInput = {
-        ...mockedConnectorInput,
-        authentication: mockedConnectorInput.fields.userToken,
+        ...connectorInput,
+        authentication: connectorInput.fields.userToken,
       };
       await sanitizeInput(mockedInput);
       chai.expect(mockedInput).to.deep.equal({
-        ...mockedConnectorInput,
-        authentication: mockedConnectorInput.fields.userToken,
+        ...connectorInput,
+        authentication: connectorInput.fields.userToken,
         fields: {
-          ...mockedConnectorInput.fields,
+          ...connectorInput.fields,
           contractAddress: "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
           chain: "eip155:123",
           chainId: "123",
@@ -167,7 +174,7 @@ describe("Gnosis Safe index test", async function () {
 
     it("Should throw an error if no authentication provided and chainId and contractAddress are not in input.fields", async function () {
       const mockedInput = {
-        ...mockedConnectorInput,
+        ...connectorInput,
       };
       delete mockedInput.fields.contractAddress;
       await chai
@@ -178,16 +185,16 @@ describe("Gnosis Safe index test", async function () {
 
     it("Should set contractAddress and chainId from API call if chainId and contractAddress are not in input.fields", async function () {
       const mockedInput = {
-        ...mockedConnectorInput,
-        authentication: mockedConnectorInput.fields.userToken,
+        ...connectorInput,
+        authentication: connectorInput.fields.userToken,
       };
       delete mockedInput.fields.contractAddress;
       await sanitizeInput(mockedInput);
       chai.expect(mockedInput).to.deep.equal({
-        ...mockedConnectorInput,
-        authentication: mockedConnectorInput.fields.userToken,
+        ...connectorInput,
+        authentication: connectorInput.fields.userToken,
         fields: {
-          ...mockedConnectorInput.fields,
+          ...connectorInput.fields,
           contractAddress: "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
           chain: "eip155:123",
           chainId: "123",

--- a/src/test/evm/connector/gnosisSafe/index.test.ts
+++ b/src/test/evm/connector/gnosisSafe/index.test.ts
@@ -1,0 +1,198 @@
+import chai from "chai";
+import chaiHttp from "chai-http";
+import sinon from "sinon";
+import axios from "axios";
+import { sanitizeInput } from "../../../../web3/evm/connector/gnosisSafe";
+import { mockedConnectorInput } from "../../../utils";
+import chaiAsPromised from "chai-as-promised";
+
+/* eslint-disable no-unused-expressions */
+
+chai.use(chaiHttp);
+chai.use(chaiAsPromised);
+
+sinon.stub(axios, "post").resolves(
+  Promise.resolve({
+    data: {
+      chainId: "123",
+      safe: "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
+    },
+  })
+);
+
+describe("Gnosis Safe index test", async function () {
+  describe("sanitizeInput", async function () {
+    it("Should update chain in input.fields if all parameters are properly set up", async function () {
+      const mockedInput = {
+        ...mockedConnectorInput,
+        fields: {
+          ...mockedConnectorInput.fields,
+          contractAddress: "0xf7858Da8a6617f7C6d0fF2bcAFDb6D2eeDF64840",
+          chainId: "234",
+        },
+      };
+      await sanitizeInput(mockedInput);
+      chai.expect(mockedInput).to.deep.equal({
+        ...mockedConnectorInput,
+        fields: {
+          ...mockedConnectorInput.fields,
+          contractAddress: "0xf7858Da8a6617f7C6d0fF2bcAFDb6D2eeDF64840",
+          chainId: "234",
+          chain: "eip155:234",
+        },
+      });
+    });
+
+    it("Should update chainId in input.fields via _grinderyChain in input.fields", async function () {
+      const mockedInput = {
+        ...mockedConnectorInput,
+        authentication: mockedConnectorInput.fields.userToken,
+        fields: { ...mockedConnectorInput.fields, _grinderyChain: "eip155:234" },
+      };
+      await sanitizeInput(mockedInput);
+      chai.expect(mockedInput).to.deep.equal({
+        ...mockedConnectorInput,
+        authentication: mockedConnectorInput.fields.userToken,
+        fields: {
+          ...mockedConnectorInput.fields,
+          chainId: "234",
+          chain: "eip155:234",
+        },
+      });
+    });
+
+    it("Should update chainId in input.fields via API call if _grinderyChain in input.fields is bad formatted", async function () {
+      const mockedInput = {
+        ...mockedConnectorInput,
+        authentication: mockedConnectorInput.fields.userToken,
+        fields: { ...mockedConnectorInput.fields, _grinderyChain: "eip15:234" },
+      };
+      await sanitizeInput(mockedInput);
+      chai.expect(mockedInput).to.deep.equal({
+        ...mockedConnectorInput,
+        authentication: mockedConnectorInput.fields.userToken,
+        fields: {
+          ...mockedConnectorInput.fields,
+          contractAddress: "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
+          chainId: "123",
+          chain: "eip155:123",
+        },
+      });
+    });
+
+    it("Should update contractAddress in input.fields via _grinderyContractAddress in input.fields", async function () {
+      const mockedInput = {
+        ...mockedConnectorInput,
+        authentication: mockedConnectorInput.fields.userToken,
+        fields: {
+          ...mockedConnectorInput.fields,
+          chainId: "234",
+          _grinderyContractAddress: "0x78e79E270eE8B43b15E22a23650Aba749272365B",
+        },
+      };
+      delete mockedInput.fields.contractAddress;
+      await sanitizeInput(mockedInput);
+      chai.expect(mockedInput).to.deep.equal({
+        ...mockedConnectorInput,
+        authentication: mockedConnectorInput.fields.userToken,
+        fields: {
+          ...mockedConnectorInput.fields,
+          chainId: "234",
+          chain: "eip155:234",
+          contractAddress: "0x78e79E270eE8B43b15E22a23650Aba749272365B",
+        },
+      });
+    });
+
+    it("Should throw an error if no authentication provided and contractAddress is not in input.fields", async function () {
+      const mockedInput = {
+        ...mockedConnectorInput,
+        fields: { ...mockedConnectorInput.fields, chainId: "234" },
+      };
+      delete mockedInput.fields.contractAddress;
+      await chai
+        .expect(sanitizeInput(mockedInput))
+        .to.eventually.be.rejected.and.be.an.instanceOf(Error)
+        .and.have.property("message", "Authentication required");
+    });
+
+    it("Should set contractAddress and chainId from API call if contractAddress is not in input.fields", async function () {
+      const mockedInput = {
+        ...mockedConnectorInput,
+        authentication: mockedConnectorInput.fields.userToken,
+        fields: { ...mockedConnectorInput.fields, chainId: "234" },
+      };
+      delete mockedInput.fields.contractAddress;
+      await sanitizeInput(mockedInput);
+      chai.expect(mockedInput).to.deep.equal({
+        ...mockedConnectorInput,
+        authentication: mockedConnectorInput.fields.userToken,
+        fields: {
+          ...mockedConnectorInput.fields,
+          contractAddress: "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
+          chain: "eip155:123",
+          chainId: "123",
+        },
+      });
+    });
+
+    it("Should throw an error if no authentication provided and chainId is not in input.fields", async function () {
+      await chai
+        .expect(
+          sanitizeInput({
+            ...mockedConnectorInput,
+          })
+        )
+        .to.eventually.be.rejected.and.be.an.instanceOf(Error)
+        .and.have.property("message", "Authentication required");
+    });
+
+    it("Should set contractAddress and chainId from API call if chainId is not in input.fields", async function () {
+      const mockedInput = {
+        ...mockedConnectorInput,
+        authentication: mockedConnectorInput.fields.userToken,
+      };
+      await sanitizeInput(mockedInput);
+      chai.expect(mockedInput).to.deep.equal({
+        ...mockedConnectorInput,
+        authentication: mockedConnectorInput.fields.userToken,
+        fields: {
+          ...mockedConnectorInput.fields,
+          contractAddress: "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
+          chain: "eip155:123",
+          chainId: "123",
+        },
+      });
+    });
+
+    it("Should throw an error if no authentication provided and chainId and contractAddress are not in input.fields", async function () {
+      const mockedInput = {
+        ...mockedConnectorInput,
+      };
+      delete mockedInput.fields.contractAddress;
+      await chai
+        .expect(sanitizeInput(mockedInput))
+        .to.eventually.be.rejected.and.be.an.instanceOf(Error)
+        .and.have.property("message", "Authentication required");
+    });
+
+    it("Should set contractAddress and chainId from API call if chainId and contractAddress are not in input.fields", async function () {
+      const mockedInput = {
+        ...mockedConnectorInput,
+        authentication: mockedConnectorInput.fields.userToken,
+      };
+      delete mockedInput.fields.contractAddress;
+      await sanitizeInput(mockedInput);
+      chai.expect(mockedInput).to.deep.equal({
+        ...mockedConnectorInput,
+        authentication: mockedConnectorInput.fields.userToken,
+        fields: {
+          ...mockedConnectorInput.fields,
+          contractAddress: "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
+          chain: "eip155:123",
+          chainId: "123",
+        },
+      });
+    });
+  });
+});

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -4,6 +4,7 @@ import { sanitizeParameters } from "../utils";
 import sinon from "sinon";
 import * as unitConverter from "../web3/evm/unitConverter";
 import { mockedConnectorInput } from "./utils";
+import { ConnectorInput } from "grindery-nexus-common-utils";
 
 /* eslint-disable no-unused-expressions */
 
@@ -20,27 +21,33 @@ sinon
     return "1";
   });
 
+let connectorInput: ConnectorInput<any>;
+
+before(async () => {
+  connectorInput = await mockedConnectorInput;
+});
+
 describe("Utils test", async function () {
   describe("sanitizeParameters", async function () {
     it("Should not modify ConnectorInput  in the simplest case", async function () {
-      chai.expect(await sanitizeParameters(mockedConnectorInput)).to.deep.equal(mockedConnectorInput);
+      chai.expect(await sanitizeParameters(connectorInput)).to.deep.equal(connectorInput);
     });
 
     it("Should transfer _grinderyContractAddress to contractAddress in fields", async function () {
       chai
         .expect(
           await sanitizeParameters({
-            ...mockedConnectorInput,
+            ...connectorInput,
             fields: {
-              ...mockedConnectorInput.fields,
+              ...connectorInput.fields,
               _grinderyContractAddress: "0x388C818CA8B9251b393131C08a736A67ccB19297",
             },
           })
         )
         .to.deep.equal({
-          ...mockedConnectorInput,
+          ...connectorInput,
           fields: {
-            ...mockedConnectorInput.fields,
+            ...connectorInput.fields,
             contractAddress: "0x388C818CA8B9251b393131C08a736A67ccB19297",
           },
         });
@@ -50,17 +57,17 @@ describe("Utils test", async function () {
       chai
         .expect(
           await sanitizeParameters({
-            ...mockedConnectorInput,
+            ...connectorInput,
             fields: {
-              ...mockedConnectorInput.fields,
+              ...connectorInput.fields,
               _grinderyChain: "eip155:250",
             },
           })
         )
         .to.deep.equal({
-          ...mockedConnectorInput,
+          ...connectorInput,
           fields: {
-            ...mockedConnectorInput.fields,
+            ...connectorInput.fields,
             chain: "eip155:250",
           },
         });
@@ -70,17 +77,17 @@ describe("Utils test", async function () {
       chai
         .expect(
           await sanitizeParameters({
-            ...mockedConnectorInput,
+            ...connectorInput,
             fields: {
-              ...mockedConnectorInput.fields,
+              ...connectorInput.fields,
               parameters: { to: "0x388C818CA8B9251b393131C08a736A67ccB19297", value: "!!GRINDERY!!UNDEFINED!!" },
             },
           })
         )
         .to.deep.equal({
-          ...mockedConnectorInput,
+          ...connectorInput,
           fields: {
-            ...mockedConnectorInput.fields,
+            ...connectorInput.fields,
             parameters: { to: "0x388C818CA8B9251b393131C08a736A67ccB19297", value: undefined },
           },
         });
@@ -90,9 +97,9 @@ describe("Utils test", async function () {
       chai
         .expect(
           await sanitizeParameters({
-            ...mockedConnectorInput,
+            ...connectorInput,
             fields: {
-              ...mockedConnectorInput.fields,
+              ...connectorInput.fields,
               parameters: {
                 to: "0x388C818CA8B9251b393131C08a736A67ccB19297",
                 value: "1000",
@@ -102,9 +109,9 @@ describe("Utils test", async function () {
           })
         )
         .to.deep.equal({
-          ...mockedConnectorInput,
+          ...connectorInput,
           fields: {
-            ...mockedConnectorInput.fields,
+            ...connectorInput.fields,
             parameters: {
               to: "0x388C818CA8B9251b393131C08a736A67ccB19297",
               value: "1",
@@ -118,9 +125,9 @@ describe("Utils test", async function () {
       chai
         .expect(
           await sanitizeParameters({
-            ...mockedConnectorInput,
+            ...connectorInput,
             fields: {
-              ...mockedConnectorInput.fields,
+              ...connectorInput.fields,
               parameterFilters: {
                 to: "0x388C818CA8B9251b393131C08a736A67ccB19297",
                 value: "1000",
@@ -130,9 +137,9 @@ describe("Utils test", async function () {
           })
         )
         .to.deep.equal({
-          ...mockedConnectorInput,
+          ...connectorInput,
           fields: {
-            ...mockedConnectorInput.fields,
+            ...connectorInput.fields,
             parameterFilters: {
               to: "0x388C818CA8B9251b393131C08a736A67ccB19297",
               value: "1",
@@ -147,9 +154,9 @@ describe("Utils test", async function () {
         .expect(
           await sanitizeParameters(
             {
-              ...mockedConnectorInput,
+              ...connectorInput,
               fields: {
-                ...mockedConnectorInput.fields,
+                ...connectorInput.fields,
                 to: "0x388C818CA8B9251b393131C08a736A67ccB19297",
                 value: "1000",
                 _grinderyUnitConversion_value: "erc20Decimals[@]",
@@ -159,9 +166,9 @@ describe("Utils test", async function () {
           )
         )
         .to.deep.equal({
-          ...mockedConnectorInput,
+          ...connectorInput,
           fields: {
-            ...mockedConnectorInput.fields,
+            ...connectorInput.fields,
             to: "0x388C818CA8B9251b393131C08a736A67ccB19297",
             value: "1",
             _grinderyUnitConversion_value: "erc20Decimals[@]",

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,30 +1,13 @@
 import chai from "chai";
 import chaiHttp from "chai-http";
 import { sanitizeParameters } from "../utils";
-import { ConnectorInput } from "grindery-nexus-common-utils";
 import sinon from "sinon";
 import * as unitConverter from "../web3/evm/unitConverter";
+import { mockedConnectorInput } from "./utils";
 
 /* eslint-disable no-unused-expressions */
 
 chai.use(chaiHttp);
-
-const mockedConnectorInput: ConnectorInput<any> = {
-  sessionId: "mySessionId",
-  cdsName: "myCdsName",
-  key: "totalSupplyAction",
-  fields: {
-    chain: "eip155:5",
-    contractAddress: "0xD6dAC59F68089CE0c82310Ec213Ac9E25561a5f0",
-    parameters: {
-      to: "0x388C818CA8B9251b393131C08a736A67ccB19297",
-      value: "1000",
-    },
-    functionDeclaration: "function transfer(address to, uint256 value) public virtual returns (bool) ",
-    userToken:
-      "eyJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJ1cm46Z3JpbmRlcnk6YWNjZXNzLXRva2VuOnYxIiwic3ViIjoiZWlwMTU1OjE6MHgxMEEyQzMwNmNDYzg3OTM4QjFmZTNjNjNEQmIxNDU3QTljODEwZGY1IiwiaWF0IjoxNjg3MjcwOTk1LCJpc3MiOiJ1cm46Z3JpbmRlcnk6b3JjaGVzdHJhdG9yIiwiZXhwIjoxNjg3Mjc0NTk1fQ.WUEC1GFkRACK7rdwcV0kt08_m4-YDzifkWPWcdhsVzDAunevAnDD5mqILDX7Czn92eMUZy1hb3IFPJQyTzNQnw",
-  },
-};
 
 sinon
   .stub(unitConverter, "convert")

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,3 +1,4 @@
+import { ConnectorInput } from "grindery-nexus-common-utils";
 import { TAccessToken } from "../jwt";
 
 export const mockedTAccessToken: TAccessToken = {
@@ -6,4 +7,21 @@ export const mockedTAccessToken: TAccessToken = {
   iat: 1690548968,
   iss: "urn:grindery:orchestrator",
   exp: 1690552568,
+};
+
+export const mockedConnectorInput: ConnectorInput<any> = {
+  sessionId: "mySessionId",
+  cdsName: "myCdsName",
+  key: "totalSupplyAction",
+  fields: {
+    chain: "eip155:5",
+    contractAddress: "0xD6dAC59F68089CE0c82310Ec213Ac9E25561a5f0",
+    parameters: {
+      to: "0x388C818CA8B9251b393131C08a736A67ccB19297",
+      value: "1000",
+    },
+    functionDeclaration: "function transfer(address to, uint256 value) public virtual returns (bool) ",
+    userToken:
+      "eyJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJ1cm46Z3JpbmRlcnk6YWNjZXNzLXRva2VuOnYxIiwic3ViIjoiZWlwMTU1OjE6MHgxMEEyQzMwNmNDYzg3OTM4QjFmZTNjNjNEQmIxNDU3QTljODEwZGY1IiwiaWF0IjoxNjg3MjcwOTk1LCJpc3MiOiJ1cm46Z3JpbmRlcnk6b3JjaGVzdHJhdG9yIiwiZXhwIjoxNjg3Mjc0NTk1fQ.WUEC1GFkRACK7rdwcV0kt08_m4-YDzifkWPWcdhsVzDAunevAnDD5mqILDX7Czn92eMUZy1hb3IFPJQyTzNQnw",
+  },
 };

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,5 +1,5 @@
 import { ConnectorInput } from "grindery-nexus-common-utils";
-import { TAccessToken } from "../jwt";
+import { TAccessToken, signJWT } from "../jwt";
 
 export const mockedTAccessToken: TAccessToken = {
   aud: "urn:grindery:access-token:v1",
@@ -9,19 +9,24 @@ export const mockedTAccessToken: TAccessToken = {
   exp: 1690552568,
 };
 
-export const mockedConnectorInput: ConnectorInput<any> = {
-  sessionId: "mySessionId",
-  cdsName: "myCdsName",
-  key: "totalSupplyAction",
-  fields: {
-    chain: "eip155:5",
-    contractAddress: "0xD6dAC59F68089CE0c82310Ec213Ac9E25561a5f0",
-    parameters: {
-      to: "0x388C818CA8B9251b393131C08a736A67ccB19297",
-      value: "1000",
+const createMockedConnectorInput = async () => {
+  const mockedInput: ConnectorInput<any> = {
+    sessionId: "mySessionId",
+    cdsName: "myCdsName",
+    key: "totalSupplyAction",
+    fields: {
+      chain: "eip155:5",
+      contractAddress: "0xD6dAC59F68089CE0c82310Ec213Ac9E25561a5f0",
+      parameters: {
+        to: "0x388C818CA8B9251b393131C08a736A67ccB19297",
+        value: "1000",
+      },
+      functionDeclaration: "function transfer(address to, uint256 value) public virtual returns (bool) ",
+      userToken: await signJWT({ sub: "x" }, "60s"),
     },
-    functionDeclaration: "function transfer(address to, uint256 value) public virtual returns (bool) ",
-    userToken:
-      "eyJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJ1cm46Z3JpbmRlcnk6YWNjZXNzLXRva2VuOnYxIiwic3ViIjoiZWlwMTU1OjE6MHgxMEEyQzMwNmNDYzg3OTM4QjFmZTNjNjNEQmIxNDU3QTljODEwZGY1IiwiaWF0IjoxNjg3MjcwOTk1LCJpc3MiOiJ1cm46Z3JpbmRlcnk6b3JjaGVzdHJhdG9yIiwiZXhwIjoxNjg3Mjc0NTk1fQ.WUEC1GFkRACK7rdwcV0kt08_m4-YDzifkWPWcdhsVzDAunevAnDD5mqILDX7Czn92eMUZy1hb3IFPJQyTzNQnw",
-  },
+  };
+
+  return mockedInput;
 };
+
+export const mockedConnectorInput = createMockedConnectorInput();

--- a/src/web3/evm/connector/gnosisSafe/index.ts
+++ b/src/web3/evm/connector/gnosisSafe/index.ts
@@ -15,12 +15,19 @@ import Web3 from "web3";
 const ERC20_TRANSFER = ERC20.find((item) => item.name === "transfer");
 const nonceMutexes: { [contractAddress: string]: () => Promise<() => void> } = {};
 
-async function sanitizeInput(input: ConnectorInput<unknown>) {
+/**
+ * Sanitizes the input fields in the provided ConnectorInput object.
+ *
+ * @param input - The ConnectorInput object containing the input fields to sanitize.
+ * @throws {Error} Throws an error if authentication is required but not provided
+ */
+export async function sanitizeInput(input: ConnectorInput<unknown>) {
   const parameters = input.fields as { [key: string]: string };
   const m = /^eip155:(\d+)$/.exec(parameters._grinderyChain || "");
   if (m) {
     parameters.chainId = m[1];
   }
+  delete parameters._grinderyChain;
   parameters.contractAddress = parameters.contractAddress || parameters._grinderyContractAddress;
   if (!["chainId", "contractAddress"].every((x) => parameters[x])) {
     if (!input.authentication) {
@@ -38,8 +45,7 @@ async function sanitizeInput(input: ConnectorInput<unknown>) {
         },
       }
     );
-    const chainId = authResp.data.chainId;
-    parameters.chainId = chainId;
+    parameters.chainId = authResp.data.chainId;
     parameters.contractAddress = authResp.data.safe;
   }
   parameters.chain = `eip155:${parameters.chainId}`;


### PR DESCRIPTION
This PR contains:
- Unit tests to assess the proper implementation of GnosisSafe `sanitizeInput` function.
- A bit of refactoring of GnosisSafe `sanitizeInput` function.
- Some function documentation for GnosisSafe `sanitizeInput` function
- A fix on `parameters._grinderyChain` that is deleted after regex matching. Before, if `_grinderyChain` was not well formatted, for example `eip15:234` then the matching in the regex did not match and `parameters.chainId` remained `undefined` and then modified by the API call, which is completely normal. However, there was still `parameters._grinderyChain: eip15:234`. Then came the call to `sanitizeParameters` and the item `fields.chain` was replaced by `parameters._grinderyChain: eip15:234` before this last item was deleted, which therefore created an inconsistency with the `fields.chainId` obtained by the API call. Now, if `_grinderyChain` is incorrectly formatted, then the `fields.chain` and `fields.chainId` items are taken from the API call.