### PR TITLE
feat(tests): add unit tests for unit converter

### DIFF
--- a/src/test/unit-converter.test.ts
+++ b/src/test/unit-converter.test.ts
@@ -1,0 +1,139 @@
+import chai from "chai";
+import { numberToString, scaleDecimals } from "../web3/evm/unitConverter";
+
+describe("numberToString", async function () {
+  it("Should convert a valid string number to string", async function () {
+    chai.expect(numberToString("42")).to.equal("42");
+    chai.expect(numberToString("8.15")).to.equal("8.15");
+    chai.expect(numberToString("-50")).to.equal("-50");
+    chai.expect(numberToString("-3.14")).to.equal("-3.14");
+    chai.expect(numberToString("0")).to.equal("0");
+  });
+
+  it("Should throw an error if string is invalid", async function () {
+    chai
+      .expect(() => numberToString("/42"))
+      .to.throw(Error)
+      .with.property(
+        "message",
+        "while converting number to string, invalid number value '/42', should be a number matching (^-?[0-9.]+)."
+      );
+    chai
+      .expect(() => numberToString("&42"))
+      .to.throw(Error)
+      .with.property(
+        "message",
+        "while converting number to string, invalid number value '&42', should be a number matching (^-?[0-9.]+)."
+      );
+    chai
+      .expect(() => numberToString(" 42"))
+      .to.throw(Error)
+      .with.property(
+        "message",
+        "while converting number to string, invalid number value ' 42', should be a number matching (^-?[0-9.]+)."
+      );
+  });
+
+  it("Should convert a number to string", async function () {
+    chai.expect(numberToString(42)).to.equal("42");
+    chai.expect(numberToString(8.15)).to.equal("8.15");
+    chai.expect(numberToString(-50)).to.equal("-50");
+    chai.expect(numberToString(-3.14)).to.equal("-3.14");
+    chai.expect(numberToString(0)).to.equal("0");
+  });
+
+  it("Should convert an object with toString method to string", async () => {
+    let customValue = "42";
+    const objWithToString = {
+      toString: () => customValue.toString(),
+      toTwos: () => "",
+      dividedToIntegerBy: () => "",
+    };
+    chai.expect(numberToString(objWithToString)).to.equal("42");
+    customValue = "8.15";
+    chai.expect(numberToString(objWithToString)).to.equal("8.15");
+    customValue = "-50";
+    chai.expect(numberToString(objWithToString)).to.equal("-50");
+    customValue = "-3.14";
+    chai.expect(numberToString(objWithToString)).to.equal("-3.14");
+    customValue = "0";
+    chai.expect(numberToString(objWithToString)).to.equal("0");
+  });
+
+  it("Should throw an error for invalid inputs", async () => {
+    chai
+      .expect(() => numberToString("invalid"))
+      .to.throw(Error)
+      .with.property(
+        "message",
+        "while converting number to string, invalid number value 'invalid', should be a number matching (^-?[0-9.]+)."
+      );
+    chai
+      .expect(() => numberToString({}))
+      .to.throw(Error)
+      .with.property(
+        "message",
+        "while converting number to string, invalid number value '[object Object]' type object."
+      );
+    chai
+      .expect(() => numberToString([]))
+      .to.throw(Error)
+      .with.property("message", "while converting number to string, invalid number value '' type object.");
+  });
+});
+
+describe("scaleDecimals", async function () {
+  it("Should correctly integer decimals", async () => {
+    const decimals = 18;
+    const weiValue = scaleDecimals("50", decimals);
+    chai.expect(weiValue).to.equal("50000000000000000000");
+  });
+
+  it("Should correctly scale decimals", async () => {
+    const decimals = 18;
+    const weiValue = scaleDecimals("1.23456789", decimals);
+    chai.expect(weiValue).to.equal("1234567890000000000");
+  });
+
+  it("Should handle negative numbers", async () => {
+    const decimals = 10;
+    const weiValue = scaleDecimals("-123.456789", decimals);
+    chai.expect(weiValue).to.equal("-1234567890000");
+  });
+
+  it("Should handle zero number", async () => {
+    const decimals = 8;
+    const weiValue = scaleDecimals("0", decimals);
+    chai.expect(weiValue).to.equal("0");
+  });
+
+  it("Should handle decimals with trailing zeros", async () => {
+    const decimals = 10;
+    const weiValue = scaleDecimals("123.400000", decimals);
+    chai.expect(weiValue).to.equal("1234000000000");
+  });
+
+  it("Should throw an error for too many decimal points", async () => {
+    const decimals = 18;
+    chai
+      .expect(() => scaleDecimals("1.2.3", decimals))
+      .to.throw(Error, "[ethjs-unit] while converting number 1.2.3 to wei,  too many decimal points");
+  });
+
+  it("Should throw an error for too many decimal places", async () => {
+    const decimals = 6;
+    chai
+      .expect(() => scaleDecimals("123.45678321312312312329", decimals))
+      .to.throw(Error, "[ethjs-unit] while converting number 123.45678321312312312329 to wei, too many decimal places");
+  });
+
+  it("Should throw an error for invalid characters", async () => {
+    const decimals = 18;
+    chai
+      .expect(() => scaleDecimals("1a2b3c4d", decimals))
+      .to.throw(
+        Error,
+        "while converting number to string, invalid number value '1a2b3c4d', should be a number matching (^-?[0-9.]+)"
+      );
+  });
+});

--- a/src/test/unit-converter.test.ts
+++ b/src/test/unit-converter.test.ts
@@ -180,7 +180,6 @@ describe("Unit Converter", async function () {
 
   describe("UNIT_CONVERTERS", async () => {
     it("Should return the correct value for valid contract address and valid input format with commas", async () => {
-      // Test case for a contract address with valid input format (with commas)
       const value = "123,456.78";
       const contractAddress = "0x04c496af5321D9E03fd10a67CA6C23474bFc8475";
       const fields: Record<string, unknown> = {

--- a/src/test/unit-converter.test.ts
+++ b/src/test/unit-converter.test.ts
@@ -16,7 +16,7 @@ describe("Unit Converter", async function () {
         decimals: sandbox.stub().resolves("18"),
       },
     };
-    getWeb3 = (chain: string) => {
+    getWeb3 = () => {
       const web3Stub = {
         eth: {
           Contract: sandbox.stub().returns(contractStub),
@@ -185,7 +185,7 @@ describe("Unit Converter", async function () {
       const contractAddress = "0x04c496af5321D9E03fd10a67CA6C23474bFc8475";
       const fields: Record<string, unknown> = {
         chain: "eip155:1",
-        contractAddress: contractAddress,
+        contractAddress,
       };
       const parameters: Record<string, unknown> = {
         parameterName: "parameterValue",
@@ -202,7 +202,7 @@ describe("Unit Converter", async function () {
       const contractAddress = "0x04c496af5321D9E03fd10a67CA6C23474bFc8475";
       const fields: Record<string, unknown> = {
         chain: "eip155:1",
-        contractAddress: contractAddress,
+        contractAddress,
       };
       const parameters: Record<string, unknown> = {
         parameterName: "parameterValue",
@@ -215,10 +215,10 @@ describe("Unit Converter", async function () {
 
     it('Should use contractAddress from fields when contractAddress is "@"', async () => {
       const value = "123,456.78";
-      const contractAddressFromFields = "0x1234567890";
+      const contractAddress = "0x1234567890";
       const fields: Record<string, unknown> = {
         chain: "ethereum",
-        contractAddress: contractAddressFromFields,
+        contractAddress,
       };
       const parameters: Record<string, unknown> = {
         parameterName: "parameterValue",
@@ -230,18 +230,18 @@ describe("Unit Converter", async function () {
 
     it("Should throw an error for invalid contract address", async () => {
       const value = "123,456.78";
-      const invalidContractAddress = "invalid-address";
+      const contractAddress = "invalid-address";
       const fields: Record<string, unknown> = {
         chain: "eip155:1",
-        contractAddress: invalidContractAddress,
+        contractAddress,
       };
       const parameters: Record<string, unknown> = {
         parameterName: "parameterValue",
       };
 
       await chai
-        .expect(UNIT_CONVERTERS[0][1](value, ["unused", invalidContractAddress], fields, parameters))
-        .to.be.rejectedWith(Error, `erc20Decimals: Invalid contract address: ${invalidContractAddress}`);
+        .expect(UNIT_CONVERTERS[0][1](value, ["unused", contractAddress], fields, parameters))
+        .to.be.rejectedWith(Error, `erc20Decimals: Invalid contract address: ${contractAddress}`);
     });
   });
 });

--- a/src/test/unit-converter.test.ts
+++ b/src/test/unit-converter.test.ts
@@ -1,5 +1,10 @@
 import chai from "chai";
-import { numberToString, scaleDecimals } from "../web3/evm/unitConverter";
+import chaiHttp from "chai-http";
+import { UNIT_CONVERTERS, numberToString, scaleDecimals } from "../web3/evm/unitConverter";
+import sinon from "sinon";
+import * as web3 from "../web3/evm/web3";
+
+chai.use(chaiHttp);
 
 describe("numberToString", async function () {
   it("Should convert a valid string number to string", async function () {
@@ -135,5 +140,40 @@ describe("scaleDecimals", async function () {
         Error,
         "while converting number to string, invalid number value '1a2b3c4d', should be a number matching (^-?[0-9.]+)"
       );
+  });
+});
+
+describe("UNIT_CONVERTERS", async () => {
+  it("should convert ERC20 token value to scaled decimals", async () => {
+    const contractStub = {
+      methods: {
+        decimals: sinon.stub().resolves("18"),
+      },
+    };
+
+    const getWeb3 = (chain: string) => {
+      const web3Stub = {
+        eth: {
+          Contract: sinon.stub().returns(contractStub),
+        },
+      };
+
+      const closeStub = sinon.stub();
+
+      return {
+        web3: web3Stub,
+        close: closeStub,
+      };
+    };
+
+    sinon.stub(web3, "getWeb3").callsFake(getWeb3);
+
+    contractStub.methods.decimals = sinon.stub().returns({
+      call: sinon.stub().resolves("18"),
+    });
+
+    // code
+
+    sinon.restore();
   });
 });

--- a/src/test/unit-converter.test.ts
+++ b/src/test/unit-converter.test.ts
@@ -3,177 +3,252 @@ import chaiHttp from "chai-http";
 import { UNIT_CONVERTERS, numberToString, scaleDecimals } from "../web3/evm/unitConverter";
 import sinon from "sinon";
 import * as web3 from "../web3/evm/web3";
+import chaiAsPromised from "chai-as-promised";
 
 chai.use(chaiHttp);
+chai.use(chaiAsPromised);
 
-describe("numberToString", async function () {
-  it("Should convert a valid string number to string", async function () {
-    chai.expect(numberToString("42")).to.equal("42");
-    chai.expect(numberToString("8.15")).to.equal("8.15");
-    chai.expect(numberToString("-50")).to.equal("-50");
-    chai.expect(numberToString("-3.14")).to.equal("-3.14");
-    chai.expect(numberToString("0")).to.equal("0");
+describe("Unit Converter", async function () {
+  describe("numberToString", async function () {
+    it("Should convert a valid string number to string", async function () {
+      chai.expect(numberToString("42")).to.equal("42");
+      chai.expect(numberToString("8.15")).to.equal("8.15");
+      chai.expect(numberToString("-50")).to.equal("-50");
+      chai.expect(numberToString("-3.14")).to.equal("-3.14");
+      chai.expect(numberToString("0")).to.equal("0");
+    });
+
+    it("Should throw an error if string is invalid", async function () {
+      chai
+        .expect(() => numberToString("/42"))
+        .to.throw(Error)
+        .with.property(
+          "message",
+          "while converting number to string, invalid number value '/42', should be a number matching (^-?[0-9.]+)."
+        );
+      chai
+        .expect(() => numberToString("&42"))
+        .to.throw(Error)
+        .with.property(
+          "message",
+          "while converting number to string, invalid number value '&42', should be a number matching (^-?[0-9.]+)."
+        );
+      chai
+        .expect(() => numberToString(" 42"))
+        .to.throw(Error)
+        .with.property(
+          "message",
+          "while converting number to string, invalid number value ' 42', should be a number matching (^-?[0-9.]+)."
+        );
+    });
+
+    it("Should convert a number to string", async function () {
+      chai.expect(numberToString(42)).to.equal("42");
+      chai.expect(numberToString(8.15)).to.equal("8.15");
+      chai.expect(numberToString(-50)).to.equal("-50");
+      chai.expect(numberToString(-3.14)).to.equal("-3.14");
+      chai.expect(numberToString(0)).to.equal("0");
+    });
+
+    it("Should convert an object with toString method to string", async () => {
+      let customValue = "42";
+      const objWithToString = {
+        toString: () => customValue.toString(),
+        toTwos: () => "",
+        dividedToIntegerBy: () => "",
+      };
+      chai.expect(numberToString(objWithToString)).to.equal("42");
+      customValue = "8.15";
+      chai.expect(numberToString(objWithToString)).to.equal("8.15");
+      customValue = "-50";
+      chai.expect(numberToString(objWithToString)).to.equal("-50");
+      customValue = "-3.14";
+      chai.expect(numberToString(objWithToString)).to.equal("-3.14");
+      customValue = "0";
+      chai.expect(numberToString(objWithToString)).to.equal("0");
+    });
+
+    it("Should throw an error for invalid inputs", async () => {
+      chai
+        .expect(() => numberToString("invalid"))
+        .to.throw(Error)
+        .with.property(
+          "message",
+          "while converting number to string, invalid number value 'invalid', should be a number matching (^-?[0-9.]+)."
+        );
+      chai
+        .expect(() => numberToString({}))
+        .to.throw(Error)
+        .with.property(
+          "message",
+          "while converting number to string, invalid number value '[object Object]' type object."
+        );
+      chai
+        .expect(() => numberToString([]))
+        .to.throw(Error)
+        .with.property("message", "while converting number to string, invalid number value '' type object.");
+    });
   });
 
-  it("Should throw an error if string is invalid", async function () {
-    chai
-      .expect(() => numberToString("/42"))
-      .to.throw(Error)
-      .with.property(
-        "message",
-        "while converting number to string, invalid number value '/42', should be a number matching (^-?[0-9.]+)."
-      );
-    chai
-      .expect(() => numberToString("&42"))
-      .to.throw(Error)
-      .with.property(
-        "message",
-        "while converting number to string, invalid number value '&42', should be a number matching (^-?[0-9.]+)."
-      );
-    chai
-      .expect(() => numberToString(" 42"))
-      .to.throw(Error)
-      .with.property(
-        "message",
-        "while converting number to string, invalid number value ' 42', should be a number matching (^-?[0-9.]+)."
-      );
+  describe("scaleDecimals", async function () {
+    it("Should correctly integer decimals", async () => {
+      const decimals = 18;
+      const weiValue = scaleDecimals("50", decimals);
+      chai.expect(weiValue).to.equal("50000000000000000000");
+    });
+
+    it("Should correctly scale decimals", async () => {
+      const decimals = 18;
+      const weiValue = scaleDecimals("1.23456789", decimals);
+      chai.expect(weiValue).to.equal("1234567890000000000");
+    });
+
+    it("Should handle negative numbers", async () => {
+      const decimals = 10;
+      const weiValue = scaleDecimals("-123.456789", decimals);
+      chai.expect(weiValue).to.equal("-1234567890000");
+    });
+
+    it("Should handle zero number", async () => {
+      const decimals = 8;
+      const weiValue = scaleDecimals("0", decimals);
+      chai.expect(weiValue).to.equal("0");
+    });
+
+    it("Should handle decimals with trailing zeros", async () => {
+      const decimals = 10;
+      const weiValue = scaleDecimals("123.400000", decimals);
+      chai.expect(weiValue).to.equal("1234000000000");
+    });
+
+    it("Should throw an error for too many decimal points", async () => {
+      const decimals = 18;
+      chai
+        .expect(() => scaleDecimals("1.2.3", decimals))
+        .to.throw(Error, "[ethjs-unit] while converting number 1.2.3 to wei,  too many decimal points");
+    });
+
+    it("Should throw an error for too many decimal places", async () => {
+      const decimals = 6;
+      chai
+        .expect(() => scaleDecimals("123.45678321312312312329", decimals))
+        .to.throw(
+          Error,
+          "[ethjs-unit] while converting number 123.45678321312312312329 to wei, too many decimal places"
+        );
+    });
+
+    it("Should throw an error for invalid characters", async () => {
+      const decimals = 18;
+      chai
+        .expect(() => scaleDecimals("1a2b3c4d", decimals))
+        .to.throw(
+          Error,
+          "while converting number to string, invalid number value '1a2b3c4d', should be a number matching (^-?[0-9.]+)"
+        );
+    });
   });
 
-  it("Should convert a number to string", async function () {
-    chai.expect(numberToString(42)).to.equal("42");
-    chai.expect(numberToString(8.15)).to.equal("8.15");
-    chai.expect(numberToString(-50)).to.equal("-50");
-    chai.expect(numberToString(-3.14)).to.equal("-3.14");
-    chai.expect(numberToString(0)).to.equal("0");
-  });
+  describe("UNIT_CONVERTERS", async () => {
+    let contractStub: { methods: { decimals: object } };
+    let getWeb3: object;
 
-  it("Should convert an object with toString method to string", async () => {
-    let customValue = "42";
-    const objWithToString = {
-      toString: () => customValue.toString(),
-      toTwos: () => "",
-      dividedToIntegerBy: () => "",
-    };
-    chai.expect(numberToString(objWithToString)).to.equal("42");
-    customValue = "8.15";
-    chai.expect(numberToString(objWithToString)).to.equal("8.15");
-    customValue = "-50";
-    chai.expect(numberToString(objWithToString)).to.equal("-50");
-    customValue = "-3.14";
-    chai.expect(numberToString(objWithToString)).to.equal("-3.14");
-    customValue = "0";
-    chai.expect(numberToString(objWithToString)).to.equal("0");
-  });
-
-  it("Should throw an error for invalid inputs", async () => {
-    chai
-      .expect(() => numberToString("invalid"))
-      .to.throw(Error)
-      .with.property(
-        "message",
-        "while converting number to string, invalid number value 'invalid', should be a number matching (^-?[0-9.]+)."
-      );
-    chai
-      .expect(() => numberToString({}))
-      .to.throw(Error)
-      .with.property(
-        "message",
-        "while converting number to string, invalid number value '[object Object]' type object."
-      );
-    chai
-      .expect(() => numberToString([]))
-      .to.throw(Error)
-      .with.property("message", "while converting number to string, invalid number value '' type object.");
-  });
-});
-
-describe("scaleDecimals", async function () {
-  it("Should correctly integer decimals", async () => {
-    const decimals = 18;
-    const weiValue = scaleDecimals("50", decimals);
-    chai.expect(weiValue).to.equal("50000000000000000000");
-  });
-
-  it("Should correctly scale decimals", async () => {
-    const decimals = 18;
-    const weiValue = scaleDecimals("1.23456789", decimals);
-    chai.expect(weiValue).to.equal("1234567890000000000");
-  });
-
-  it("Should handle negative numbers", async () => {
-    const decimals = 10;
-    const weiValue = scaleDecimals("-123.456789", decimals);
-    chai.expect(weiValue).to.equal("-1234567890000");
-  });
-
-  it("Should handle zero number", async () => {
-    const decimals = 8;
-    const weiValue = scaleDecimals("0", decimals);
-    chai.expect(weiValue).to.equal("0");
-  });
-
-  it("Should handle decimals with trailing zeros", async () => {
-    const decimals = 10;
-    const weiValue = scaleDecimals("123.400000", decimals);
-    chai.expect(weiValue).to.equal("1234000000000");
-  });
-
-  it("Should throw an error for too many decimal points", async () => {
-    const decimals = 18;
-    chai
-      .expect(() => scaleDecimals("1.2.3", decimals))
-      .to.throw(Error, "[ethjs-unit] while converting number 1.2.3 to wei,  too many decimal points");
-  });
-
-  it("Should throw an error for too many decimal places", async () => {
-    const decimals = 6;
-    chai
-      .expect(() => scaleDecimals("123.45678321312312312329", decimals))
-      .to.throw(Error, "[ethjs-unit] while converting number 123.45678321312312312329 to wei, too many decimal places");
-  });
-
-  it("Should throw an error for invalid characters", async () => {
-    const decimals = 18;
-    chai
-      .expect(() => scaleDecimals("1a2b3c4d", decimals))
-      .to.throw(
-        Error,
-        "while converting number to string, invalid number value '1a2b3c4d', should be a number matching (^-?[0-9.]+)"
-      );
-  });
-});
-
-describe("UNIT_CONVERTERS", async () => {
-  it("should convert ERC20 token value to scaled decimals", async () => {
-    const contractStub = {
-      methods: {
-        decimals: sinon.stub().resolves("18"),
-      },
-    };
-
-    const getWeb3 = (chain: string) => {
-      const web3Stub = {
-        eth: {
-          Contract: sinon.stub().returns(contractStub),
+    before(function () {
+      contractStub = {
+        methods: {
+          decimals: sinon.stub().resolves("18"),
         },
       };
 
-      const closeStub = sinon.stub();
+      getWeb3 = (chain: string) => {
+        const web3Stub = {
+          eth: {
+            Contract: sinon.stub().returns(contractStub),
+          },
+        };
 
-      return {
-        web3: web3Stub,
-        close: closeStub,
+        const closeStub = sinon.stub();
+
+        return {
+          web3: web3Stub,
+          close: closeStub,
+        };
       };
-    };
 
-    sinon.stub(web3, "getWeb3").callsFake(getWeb3);
+      sinon.stub(web3, "getWeb3").callsFake(getWeb3);
 
-    contractStub.methods.decimals = sinon.stub().returns({
-      call: sinon.stub().resolves("18"),
+      contractStub.methods.decimals = sinon.stub().returns({
+        call: sinon.stub().resolves("18"),
+      });
     });
 
-    // code
+    after(function () {
+      sinon.restore();
+    });
 
-    sinon.restore();
+    it("Should return the correct value for valid contract address and valid input format with commas", async () => {
+      // Test case for a contract address with valid input format (with commas)
+      const value = "123,456.78";
+      const contractAddress = "0x04c496af5321D9E03fd10a67CA6C23474bFc8475";
+      const fields: Record<string, unknown> = {
+        chain: "eip155:1",
+        contractAddress: contractAddress,
+      };
+      const parameters: Record<string, unknown> = {
+        parameterName: "parameterValue",
+      };
+
+      const result = await UNIT_CONVERTERS[0][1](value, ["unused", contractAddress], fields, parameters);
+
+      chai.expect(result).to.equal("123456780000000000000000");
+    });
+
+    it("Should return the correct value for valid contract address and valid input format without commas", async () => {
+      // Test case for a contract address with valid input format (without commas)
+      const value = "123456.78";
+      const contractAddress = "0x04c496af5321D9E03fd10a67CA6C23474bFc8475";
+      const fields: Record<string, unknown> = {
+        chain: "eip155:1",
+        contractAddress: contractAddress,
+      };
+      const parameters: Record<string, unknown> = {
+        parameterName: "parameterValue",
+      };
+
+      const result = await UNIT_CONVERTERS[0][1](value, ["unused", contractAddress], fields, parameters);
+
+      chai.expect(result).to.equal("123456780000000000000000");
+    });
+
+    it('Should use contractAddress from fields when contractAddress is "@"', async () => {
+      const value = "123,456.78";
+      const contractAddressFromFields = "0x1234567890";
+      const fields: Record<string, unknown> = {
+        chain: "ethereum",
+        contractAddress: contractAddressFromFields,
+      };
+      const parameters: Record<string, unknown> = {
+        parameterName: "parameterValue",
+      };
+
+      const result = await UNIT_CONVERTERS[0][1](value, ["unused", "@"], fields, parameters);
+      chai.expect(result).to.equal("123456780000000000000000");
+    });
+
+    it("Should throw an error for invalid contract address", async () => {
+      const value = "123,456.78";
+      const invalidContractAddress = "invalid-address";
+      const fields: Record<string, unknown> = {
+        chain: "eip155:1",
+        contractAddress: invalidContractAddress,
+      };
+      const parameters: Record<string, unknown> = {
+        parameterName: "parameterValue",
+      };
+
+      await chai
+        .expect(UNIT_CONVERTERS[0][1](value, ["unused", invalidContractAddress], fields, parameters))
+        .to.be.rejectedWith(Error, `erc20Decimals: Invalid contract address: ${invalidContractAddress}`);
+    });
   });
 });

--- a/src/test/unit-converter.test.ts
+++ b/src/test/unit-converter.test.ts
@@ -150,6 +150,13 @@ describe("Unit Converter", async function () {
       chai.expect(weiValue).to.equal("1234000000000");
     });
 
+    it("Should throw an error for value being only a dot", async () => {
+      const decimals = 18;
+      chai
+        .expect(() => scaleDecimals(".", decimals))
+        .to.throw(Error, "[ethjs-unit] while converting number . to wei, invalid value");
+    });
+
     it("Should throw an error for too many decimal points", async () => {
       const decimals = 18;
       chai

--- a/src/test/unit-converter.test.ts
+++ b/src/test/unit-converter.test.ts
@@ -154,7 +154,7 @@ describe("Unit Converter", async function () {
       const decimals = 18;
       chai
         .expect(() => scaleDecimals("1.2.3", decimals))
-        .to.throw(Error, "[ethjs-unit] while converting number 1.2.3 to wei,  too many decimal points");
+        .to.throw(Error, "[ethjs-unit] while converting number 1.2.3 to wei, too many decimal points");
     });
 
     it("Should throw an error for too many decimal places", async () => {

--- a/src/web3/evm/unitConverter.ts
+++ b/src/web3/evm/unitConverter.ts
@@ -7,7 +7,7 @@ import { AbiItem } from "web3-utils";
 const ERC20_DECIMALS_ABI = ERC20.find((item) => item.name === "decimals");
 
 // trunk-ignore(eslint/@typescript-eslint/no-explicit-any)
-function numberToString(arg: any) {
+export function numberToString(arg: any) {
   if (typeof arg === "string") {
     if (!arg.match(/^-?[0-9.]+$/)) {
       throw new Error(
@@ -23,7 +23,7 @@ function numberToString(arg: any) {
   throw new Error(`while converting number to string, invalid number value '${arg}' type ${typeof arg}.`);
 }
 
-function scaleDecimals(etherInput: string, decimals: number) {
+export function scaleDecimals(etherInput: string, decimals: number) {
   let ether = numberToString(etherInput);
   const base = new BN(10).pow(new BN(decimals));
   const baseLength = base.toString(10).length - 1;
@@ -41,6 +41,7 @@ function scaleDecimals(etherInput: string, decimals: number) {
   // Split it into a whole and fractional part
   const comps = ether.split(".");
   if (comps.length > 2) {
+    // ok
     throw new Error(`[ethjs-unit] while converting number ${etherInput} to wei,  too many decimal points`);
   }
 
@@ -71,7 +72,7 @@ function scaleDecimals(etherInput: string, decimals: number) {
 
   return wei.toString(10);
 }
-const UNIT_CONVERTERS: [
+export const UNIT_CONVERTERS: [
   RegExp,
   (
     value: unknown,

--- a/src/web3/evm/unitConverter.ts
+++ b/src/web3/evm/unitConverter.ts
@@ -41,7 +41,6 @@ export function scaleDecimals(etherInput: string, decimals: number) {
   // Split it into a whole and fractional part
   const comps = ether.split(".");
   if (comps.length > 2) {
-    // ok
     throw new Error(`[ethjs-unit] while converting number ${etherInput} to wei,  too many decimal points`);
   }
 

--- a/src/web3/evm/unitConverter.ts
+++ b/src/web3/evm/unitConverter.ts
@@ -41,7 +41,7 @@ export function scaleDecimals(etherInput: string, decimals: number) {
   // Split it into a whole and fractional part
   const comps = ether.split(".");
   if (comps.length > 2) {
-    throw new Error(`[ethjs-unit] while converting number ${etherInput} to wei,  too many decimal points`);
+    throw new Error(`[ethjs-unit] while converting number ${etherInput} to wei, too many decimal points`);
   }
 
   let whole = comps[0];


### PR DESCRIPTION
This PR contains:

Added unit test for `unit-converter` class.

Tested components:
- `numberToString`
- `scaleDecimals`
- `UNIT_CONVERTERS`

Notes: To avoid conflicts with other test files I'm using `simon` sandbox feature to isolate environments.