### PR TITLE
feat(Gnosis): change Gnosis Safe `API_BASE`

### DIFF
--- a/src/web3/evm/connector/gnosisSafe/common.ts
+++ b/src/web3/evm/connector/gnosisSafe/common.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 
-export const API_BASE = "https://safe-client.gnosis.io/";
+export const API_BASE = "https://safe-client.safe.global/";
 function fillTransferInfo(payload: Record<string, unknown>, safeTxInfo) {
   if (safeTxInfo.txInfo?.transferInfo?.value) {
     payload.value = safeTxInfo.txInfo?.transferInfo?.value;

--- a/src/web3/evm/connector/gnosisSafe/index.ts
+++ b/src/web3/evm/connector/gnosisSafe/index.ts
@@ -11,6 +11,7 @@ import { getWeb3 } from "../../web3";
 import { sanitizeParameters } from "../../../../utils";
 import AbiCoder from "web3-eth-abi";
 import Web3 from "web3";
+import { API_BASE } from "./common";
 
 const ERC20_TRANSFER = ERC20.find((item) => item.name === "transfer");
 const nonceMutexes: { [contractAddress: string]: () => Promise<() => void> } = {};
@@ -61,7 +62,7 @@ async function proposeTransaction(input: ConnectorInput<unknown>): Promise<Actio
   try {
     try {
       const nonceResp = await axios.post(
-        `https://safe-client.gnosis.io/v2/chains/${chainId}/safes/${contractAddress}/multisig-transactions/estimations`,
+        `${API_BASE}v2/chains/${chainId}/safes/${contractAddress}/multisig-transactions/estimations`,
         { value: "0", operation: 0, to: parameters.to, data: parameters.data }
       );
       nonce = nonceResp.data.recommendedNonce;
@@ -144,16 +145,13 @@ async function proposeTransaction(input: ConnectorInput<unknown>): Promise<Actio
       };
     }
     try {
-      const resp = await axios.post(
-        `https://safe-client.gnosis.io/v1/chains/${chainId}/transactions/${contractAddress}/propose`,
-        {
-          origin: "Grindery Flow",
-          safeTxHash: txHash,
-          signature,
-          sender: await NtaSigner.getAddress(),
-          ...message,
-        }
-      );
+      const resp = await axios.post(`${API_BASE}v1/chains/${chainId}/transactions/${contractAddress}/propose`, {
+        origin: "Grindery Flow",
+        safeTxHash: txHash,
+        signature,
+        sender: await NtaSigner.getAddress(),
+        ...message,
+      });
       return { payload: resp.data };
     } catch (e) {
       console.error("Failed to send transaction to Gnosis Safe: ", e, e.response?.data, message);

--- a/src/web3/evm/gnosisSafe.ts
+++ b/src/web3/evm/gnosisSafe.ts
@@ -7,6 +7,7 @@ import vaultSigner from "./signer";
 import { SignTypedDataVersion } from "@metamask/eth-sig-util";
 import ABI from "./abi/GnosisSafe.json";
 import ERC20 from "./abi/ERC20.json";
+import { API_BASE } from "./connector/gnosisSafe/common";
 
 export const execTransactionAbi: AbiItem = ABI.find((x) => x.name === "execTransaction") as AbiItem;
 
@@ -40,7 +41,7 @@ export async function encodeExecTransaction({
       if (threshold > 1) {
         try {
           const nonceResp = await axios.post(
-            `https://safe-client.gnosis.io/v2/chains/${chainId}/safes/${contractAddress}/multisig-transactions/estimations`,
+            `${API_BASE}v2/chains/${chainId}/safes/${contractAddress}/multisig-transactions/estimations`,
             { value: "0", operation: 0, to: parameters.to, data: "0x" }
           );
           nonce = nonceResp.data.recommendedNonce;
@@ -131,16 +132,13 @@ export async function encodeExecTransaction({
         };
       }
       try {
-        const resp = await axios.post(
-          `https://safe-client.gnosis.io/v1/chains/${chainId}/transactions/${contractAddress}/propose`,
-          {
-            origin: "Grindery Nexus",
-            safeTxHash: txHash,
-            signature,
-            sender: await vaultSigner.getAddress(),
-            ...message,
-          }
-        );
+        const resp = await axios.post(`${API_BASE}v1/chains/${chainId}/transactions/${contractAddress}/propose`, {
+          origin: "Grindery Nexus",
+          safeTxHash: txHash,
+          signature,
+          sender: await vaultSigner.getAddress(),
+          ...message,
+        });
         return resp.data;
       } catch (e) {
         console.error("Failed to send transaction to Gnosis Safe: ", e, e.response?.data, message);


### PR DESCRIPTION
This PR contains:
- A change of `API_BASE` (Gnosis Safe API base URL) variable which was `https://safe-client.gnosis.io/` (incorrect path) and now migrated to `https://safe-client.safe.global/` which seems to be the correct path according to `gnosis-safe-gateway` repo:
https://github.com/safe-global/safe-client-gateway/blob/eb481938a49c29b979fe98a5577f719f42a2b2eb/README.md?plain=1#L12
- Each time this API is called, the global `API_BASE` variable is used instead of rewriting the base URL by hand each time to avoid potential mistakes and improve fluidity for future changes.