### PR TITLE
feat(accounting): add `_grinderyAccounting` for evm `callSmartContract`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { ConnectorInput } from "grindery-nexus-common-utils/dist/connector";
 import { convert } from "./web3/evm/unitConverter";
 
-export const GRINDERY_ACCOUNTING_ACTIONS = 0;
+export const ACCOUNTING_SIMPLE_ACTIONS = "2000000000";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function sanitizeObject(parameters: Record<string, unknown>, input: ConnectorInput<any>) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 import { ConnectorInput } from "grindery-nexus-common-utils/dist/connector";
 import { convert } from "./web3/evm/unitConverter";
 
+export const GRINDERY_ACCOUNTING_ACTIONS = 0;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function sanitizeObject(parameters: Record<string, unknown>, input: ConnectorInput<any>) {
   for (const key of Object.keys(parameters)) {

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -15,7 +15,7 @@ import { AbiItem } from "web3-utils";
 import AbiCoder from "web3-eth-abi";
 import { TransactionResponse } from "@ethersproject/abstract-provider";
 import { ACCOUNTING_SIMPLE_ACTIONS } from "../../utils";
-import { CHAIN_MAPPING_ACCOUNTING } from "./chains";
+import { CHAIN_MAPPING_ACCOUNTING, DEFAULT_TX_COST_RATE } from "./chains";
 
 const hubAvailability = new Map<string, boolean>();
 
@@ -186,7 +186,7 @@ export async function callSmartContract(
           payload: {
             ...result,
             _grinderyAccounting: BigNumber.from(ACCOUNTING_SIMPLE_ACTIONS)
-              .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain]))
+              .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain] || DEFAULT_TX_COST_RATE))
               .toString(),
           },
         };
@@ -285,7 +285,7 @@ export async function callSmartContract(
             _grinderyDryRunError:
               "Can't confirm that the transaction can be executed due to the following error: " + e.toString(),
             _grinderyAccounting: BigNumber.from(ACCOUNTING_SIMPLE_ACTIONS)
-              .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain]))
+              .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain] || DEFAULT_TX_COST_RATE))
               .toString(),
           },
         };
@@ -398,7 +398,7 @@ export async function callSmartContract(
               }),
           contractAddress: input.fields.contractAddress,
           _grinderyAccounting: BigNumber.from(ACCOUNTING_SIMPLE_ACTIONS)
-            .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain]))
+            .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain] || DEFAULT_TX_COST_RATE))
             .toString(),
         };
       } else {

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -185,9 +185,12 @@ export async function callSmartContract(
           sessionId: input.sessionId,
           payload: {
             ...result,
-            _grinderyAccounting: BigNumber.from(ACCOUNTING_SIMPLE_ACTIONS)
-              .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain] || DEFAULT_TX_COST_RATE))
-              .toString(),
+            _grinderyAccounting: {
+              result: BigNumber.from(ACCOUNTING_SIMPLE_ACTIONS)
+                .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain] || DEFAULT_TX_COST_RATE))
+                .toString(),
+              chain: input.fields.chain,
+            },
           },
         };
       }
@@ -284,9 +287,12 @@ export async function callSmartContract(
           payload: {
             _grinderyDryRunError:
               "Can't confirm that the transaction can be executed due to the following error: " + e.toString(),
-            _grinderyAccounting: BigNumber.from(ACCOUNTING_SIMPLE_ACTIONS)
-              .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain] || DEFAULT_TX_COST_RATE))
-              .toString(),
+            _grinderyAccounting: {
+              result: BigNumber.from(ACCOUNTING_SIMPLE_ACTIONS)
+                .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain] || DEFAULT_TX_COST_RATE))
+                .toString(),
+              chain: input.fields.chain,
+            },
           },
         };
       }
@@ -397,9 +403,12 @@ export async function callSmartContract(
                 transactionHash: "0x1122334455667788990011223344556677889900112233445566778899001122",
               }),
           contractAddress: input.fields.contractAddress,
-          _grinderyAccounting: BigNumber.from(ACCOUNTING_SIMPLE_ACTIONS)
-            .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain] || DEFAULT_TX_COST_RATE))
-            .toString(),
+          _grinderyAccounting: {
+            result: BigNumber.from(ACCOUNTING_SIMPLE_ACTIONS)
+              .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain] || DEFAULT_TX_COST_RATE))
+              .toString(),
+            chain: input.fields.chain,
+          },
         };
       } else {
         const maxFee = input.fields.gasLimit

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -518,7 +518,6 @@ export async function callSmartContract(
               contractAddress: input.fields.contractAddress,
               _grinderyAccounting: BigNumber.from(receipt.gasUsed || txConfig.gas)
                 .mul(BigNumber.from(receipt.effectiveGasPrice || txConfig.gasPrice || txConfig.maxFeePerGas))
-                .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain]))
                 .toString(),
             };
           } else {

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -14,7 +14,8 @@ import vaultSigner from "./signer";
 import { AbiItem } from "web3-utils";
 import AbiCoder from "web3-eth-abi";
 import { TransactionResponse } from "@ethersproject/abstract-provider";
-import { GRINDERY_ACCOUNTING_ACTIONS } from "../../utils";
+import { ACCOUNTING_SIMPLE_ACTIONS } from "../../utils";
+import { CHAIN_MAPPING_ACCOUNTING } from "./chains";
 
 const hubAvailability = new Map<string, boolean>();
 
@@ -182,7 +183,12 @@ export async function callSmartContract(
         return {
           key: input.key,
           sessionId: input.sessionId,
-          payload: { ...result, _grinderyAccounting: GRINDERY_ACCOUNTING_ACTIONS },
+          payload: {
+            ...result,
+            _grinderyAccounting: BigNumber.from(ACCOUNTING_SIMPLE_ACTIONS)
+              .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain]))
+              .toString(),
+          },
         };
       }
     } else {
@@ -278,6 +284,9 @@ export async function callSmartContract(
           payload: {
             _grinderyDryRunError:
               "Can't confirm that the transaction can be executed due to the following error: " + e.toString(),
+            _grinderyAccounting: BigNumber.from(ACCOUNTING_SIMPLE_ACTIONS)
+              .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain]))
+              .toString(),
           },
         };
       }
@@ -388,6 +397,9 @@ export async function callSmartContract(
                 transactionHash: "0x1122334455667788990011223344556677889900112233445566778899001122",
               }),
           contractAddress: input.fields.contractAddress,
+          _grinderyAccounting: BigNumber.from(ACCOUNTING_SIMPLE_ACTIONS)
+            .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain]))
+            .toString(),
         };
       } else {
         const maxFee = input.fields.gasLimit
@@ -504,6 +516,10 @@ export async function callSmartContract(
               ...receipt,
               returnValue: callResultDecoded,
               contractAddress: input.fields.contractAddress,
+              _grinderyAccounting: BigNumber.from(receipt.gasUsed || txConfig.gas)
+                .mul(BigNumber.from(receipt.effectiveGasPrice || txConfig.gasPrice || txConfig.maxFeePerGas))
+                .mul(BigNumber.from(CHAIN_MAPPING_ACCOUNTING[input.fields.chain]))
+                .toString(),
             };
           } else {
             throw new Error("Unexpected failure: " + resultData.returnData);

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -14,6 +14,7 @@ import vaultSigner from "./signer";
 import { AbiItem } from "web3-utils";
 import AbiCoder from "web3-eth-abi";
 import { TransactionResponse } from "@ethersproject/abstract-provider";
+import { GRINDERY_ACCOUNTING_ACTIONS } from "../../utils";
 
 const hubAvailability = new Map<string, boolean>();
 
@@ -181,7 +182,7 @@ export async function callSmartContract(
         return {
           key: input.key,
           sessionId: input.sessionId,
-          payload: result,
+          payload: { ...result, _grinderyAccounting: GRINDERY_ACCOUNTING_ACTIONS },
         };
       }
     } else {

--- a/src/web3/evm/chains.ts
+++ b/src/web3/evm/chains.ts
@@ -70,3 +70,5 @@ export const CHAIN_MAPPING_ACCOUNTING: { [key: string]: string } = {
   "eip155:44787": "1",
   "eip155:9000": "1",
 };
+
+export const DEFAULT_TX_COST_RATE = "1";

--- a/src/web3/evm/chains.ts
+++ b/src/web3/evm/chains.ts
@@ -56,7 +56,7 @@ export const CHAIN_MAPPING_ACCOUNTING: { [key: string]: string } = {
   "eip155:43114": "1",
   "eip155:56": "1",
   "eip155:250": "1",
-  "eip155:1666600000": "4",
+  "eip155:1666600000": "1",
   "eip155:25": "1",
   "eip155:1101": "1",
   "eip155:1284": "1",
@@ -67,6 +67,6 @@ export const CHAIN_MAPPING_ACCOUNTING: { [key: string]: string } = {
   "eip155:4002": "1",
   "eip155:1442": "1",
   "eip155:338": "1",
-  "eip155:44787": "3",
+  "eip155:44787": "1",
   "eip155:9000": "1",
 };

--- a/src/web3/evm/chains.ts
+++ b/src/web3/evm/chains.ts
@@ -46,3 +46,27 @@ export const CHAIN_MAPPING: { [key: string]: [string, string] } = {
   "eip155:44787": LAVANET("alfajores/rpc", "alfajores/rpc-http"),
   "eip155:9000": LAVANET("evmost/json-rpc", "evmost/json-rpc-http"),
 };
+
+export const CHAIN_MAPPING_ACCOUNTING: { [key: string]: string } = {
+  "eip155:1": "1",
+  "eip155:42161": "1",
+  "eip155:100": "1",
+  "eip155:137": "1",
+  "eip155:42220": "1",
+  "eip155:43114": "1",
+  "eip155:56": "1",
+  "eip155:250": "1",
+  "eip155:1666600000": "4",
+  "eip155:25": "1",
+  "eip155:1101": "1",
+  "eip155:1284": "1",
+  "eip155:80001": "1",
+  "eip155:5": "1",
+  "eip155:11155111": "1",
+  "eip155:97": "1",
+  "eip155:4002": "1",
+  "eip155:1442": "1",
+  "eip155:338": "1",
+  "eip155:44787": "3",
+  "eip155:9000": "1",
+};


### PR DESCRIPTION
An accounting solution to keep updated the fees spent by each user for each call to action `callSmartContract` (EVM) is proposed. It takes into account two possibilities:
- Either the call does not require special gas costs (Gnosis Safe transaction proposal, view/pure smart contract calls). Then a base fee is applied which corresponds to the transaction fee for a classic Ethereum transaction divided by 10 (simple assumption that can be discussed/modified). A simple `CHAIN_MAPPING_ACCOUNTING` mapping of all supported EVM blockchains is also added in the event that we want to weight this fee basis by a multiplicative coefficient depending on the blockchain considered (for example one can imagine heavier fees for Ethereum than for Polygon).
- Either the call requires the payment of transaction costs (gas) and then these are carried over to the actual amount in the payload.

In all cases, a `_grinderyAccounting` field is added to the payload of the final result to then be processed by the orchestrator for a future filling of the database.