### PR TITLE
feat(evm): add unit tests for evm call

### DIFF
--- a/src/test/evm/call.test.ts
+++ b/src/test/evm/call.test.ts
@@ -1,0 +1,51 @@
+import chai from "chai";
+import chaiHttp from "chai-http";
+import { onlyOnce } from "../../web3/evm/call";
+
+/* eslint-disable no-unused-expressions */
+
+chai.use(chaiHttp);
+
+describe("EVM call functions", function () {
+  describe("onlyOnce", function () {
+    it("Should execute the wrapped function only once", async function () {
+      let counter = 0;
+      const wrappedFn = onlyOnce(() => {
+        counter++;
+      });
+      wrappedFn();
+      wrappedFn();
+      wrappedFn();
+      chai.expect(counter).to.equal(1);
+    });
+
+    it("Should not execute the wrapped function if not called", async function () {
+      let counter = 0;
+      onlyOnce(() => {
+        counter++;
+      });
+      chai.expect(counter).to.equal(0);
+    });
+
+    it("Should not modify the return value of wrapped function without explicit return", async function () {
+      const wrappedFn = onlyOnce(() => {
+        // Some implementation
+      });
+      const result = wrappedFn();
+      chai.expect(result).to.be.undefined;
+    });
+
+    it("Should call the wrapped function and not modify its return value", async function () {
+      let wasCalled = false;
+      const expectedResult = "Hello, world!";
+      const wrappedFn = onlyOnce(() => {
+        wasCalled = true;
+        return expectedResult;
+      });
+
+      wrappedFn();
+
+      chai.expect(wasCalled).to.be.true;
+    });
+  });
+});

--- a/src/test/evm/call.test.ts
+++ b/src/test/evm/call.test.ts
@@ -1,8 +1,9 @@
 import chai from "chai";
 import chaiHttp from "chai-http";
-import { hubAvailability, isHubAvailable, onlyOnce } from "../../web3/evm/call";
+import { decodeDroneCallResult, hubAvailability, isHubAvailable, onlyOnce } from "../../web3/evm/call";
 import sinon from "sinon";
 import Web3 from "web3";
+import GrinderyNexusDrone from "../../web3/evm/abi/GrinderyNexusDrone.json";
 
 /* eslint-disable no-unused-expressions */
 
@@ -128,6 +129,44 @@ describe("EVM call functions", function () {
           },
         } as Web3)
       ).to.be.true;
+    });
+  });
+
+  describe("decodeDroneCallResult", function () {
+    it("Should properly decode parameters from call result", async function () {
+      chai
+        .expect(
+          decodeDroneCallResult(
+            "0x0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000025455000000000000000000000000000000000000000000000000000000000000"
+          )
+        )
+        .to.deep.equal({
+          0: true,
+          1: "0x5455",
+          __length__: 2,
+          success: true,
+          returnData: "0x5455",
+        });
+    });
+
+    it("Should return an error if call result is empty", async function () {
+      chai
+        .expect(() => decodeDroneCallResult(""))
+        .to.throw(Error)
+        .with.property(
+          "message",
+          "Returned values aren't valid, did it run Out of Gas? You might also see this error if you are not using the correct ABI for the contract you are retrieving data from, requesting data from a block number that does not exist, or querying a node which is not fully synced."
+        );
+    });
+
+    it("Should return an error if hex data is invalid", async function () {
+      chai
+        .expect(() => decodeDroneCallResult("invalid"))
+        .to.throw(Error)
+        .with.property(
+          "message",
+          'invalid arrayify value (argument="value", value="0xinvalid", code=INVALID_ARGUMENT, version=bytes/5.7.0)'
+        );
     });
   });
 });

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -17,7 +17,7 @@ import { TransactionResponse } from "@ethersproject/abstract-provider";
 import { ACCOUNTING_SIMPLE_ACTIONS } from "../../utils";
 import { CHAIN_MAPPING_ACCOUNTING, DEFAULT_TX_COST_RATE } from "./chains";
 
-const hubAvailability = new Map<string, boolean>();
+export const hubAvailability = new Map<string, boolean>();
 
 /**
  * Wraps a given function so that it can only be executed once. Subsequent calls to the returned function
@@ -57,7 +57,7 @@ const transactionMutexes: {
  * @param {Web3} web3 - The Web3 instance to interact with the blockchain.
  * @returns {Promise<boolean>} - A Promise that resolves to a boolean value indicating whether the Grindery Nexus Hub is available on the specified chain.
  */
-async function isHubAvailable(chain: string, web3: Web3): Promise<boolean> {
+export async function isHubAvailable(chain: string, web3: Web3): Promise<boolean> {
   if (!hubAvailability.has(chain)) {
     const code = await web3.eth.getCode(HUB_ADDRESS).catch(() => "");
     const hasHub = !!code && code !== "0x";

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -73,7 +73,9 @@ export async function isHubAvailable(chain: string, web3: Web3): Promise<boolean
  * @param {string} callResult - The result of the `sendTransaction` function call as a hexadecimal string.
  * @returns {any[]} - An array containing the decoded parameters from the call result.
  */
-export function decodeDroneCallResult(callResult: string) {
+export function decodeDroneCallResult(callResult: string): {
+  [key: string]: any;
+} {
   return AbiCoder.decodeParameters(
     GrinderyNexusDrone.find((x) => x.name === "sendTransaction")?.outputs || [],
     callResult

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -71,11 +71,9 @@ export async function isHubAvailable(chain: string, web3: Web3): Promise<boolean
  * Decodes the call result of a drone contract's `sendTransaction` function call.
  *
  * @param {string} callResult - The result of the `sendTransaction` function call as a hexadecimal string.
- * @returns {any[]} - An array containing the decoded parameters from the call result.
+ * @returns {Record<string, any>} - An object containing the decoded parameters from the call result.
  */
-export function decodeDroneCallResult(callResult: string): {
-  [key: string]: any;
-} {
+export function decodeDroneCallResult(callResult: string): Record<string, any> {
   return AbiCoder.decodeParameters(
     GrinderyNexusDrone.find((x) => x.name === "sendTransaction")?.outputs || [],
     callResult

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -26,7 +26,7 @@ const hubAvailability = new Map<string, boolean>();
  * @param {Function} fn - The function to be wrapped and executed only once.
  * @returns {Function} - A new function that can only be executed once.
  */
-function onlyOnce(fn: () => void): () => void {
+export function onlyOnce(fn: () => void): () => void {
   let called = false;
   return () => {
     if (called) {

--- a/src/web3/evm/call.ts
+++ b/src/web3/evm/call.ts
@@ -73,7 +73,7 @@ export async function isHubAvailable(chain: string, web3: Web3): Promise<boolean
  * @param {string} callResult - The result of the `sendTransaction` function call as a hexadecimal string.
  * @returns {any[]} - An array containing the decoded parameters from the call result.
  */
-function decodeDroneCallResult(callResult: string) {
+export function decodeDroneCallResult(callResult: string) {
   return AbiCoder.decodeParameters(
     GrinderyNexusDrone.find((x) => x.name === "sendTransaction")?.outputs || [],
     callResult


### PR DESCRIPTION
This PR contains unit test coverage for the following EVM call functions:
- `onlyOnce`
- `isHubAvailable`
- `decodeDroneCallResult`